### PR TITLE
Improve README install docs and api-reference trigger description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "roboflow",
+  "owner": {
+    "name": "Roboflow",
+    "url": "https://roboflow.com/"
+  },
+  "plugins": [
+    {
+      "name": "roboflow",
+      "description": "Roboflow computer vision skills and MCP tools for datasets, annotation, training, workflows, inference, and deployment.",
+      "author": {
+        "name": "Roboflow"
+      },
+      "category": "development",
+      "source": "./",
+      "homepage": "https://github.com/roboflow/computer-vision-skills"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "roboflow",
   "version": "0.1.0",
   "description": "Roboflow computer vision skills and MCP tools for datasets, annotation, training, workflows, inference, and deployment.",

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IDE files
+.idea/

--- a/README.md
+++ b/README.md
@@ -63,11 +63,14 @@ For a throwaway test without touching the installed-plugins list:
 codex --plugin-dir .
 ```
 
-Marketplace install (once published):
+<details>
+<summary>Marketplace install (once published)</summary>
 
 ```bash
 codex plugin install roboflow
 ```
+
+</details>
 
 Codex picks up `ROBOFLOW_API_KEY` from the same shell environment that launches the `codex` binary. Use a project-scoped `.env` if you need different keys per project.
 

--- a/README.md
+++ b/README.md
@@ -4,24 +4,6 @@ Agent-ready Roboflow skills plus MCP configuration for computer vision workflows
 
 This repository is a plugin-shaped source of truth for AI agents (Claude Code, Codex, Cursor, OpenCode, and others). The canonical skill content lives in [`skills/`](skills/); plugin manifests point at those files instead of copying them elsewhere.
 
-## Get your API key
-
-Grab your Roboflow API key from the workspace settings page:
-
-```text
-https://app.roboflow.com/{workspace}/settings/api
-```
-
-Replace `{workspace}` with your workspace slug. The key authenticates the bundled MCP server against `https://mcp.roboflow.com/mcp` via the `x-api-key` header.
-
-Export it in the shell that launches your agent:
-
-```bash
-export ROBOFLOW_API_KEY=YOUR_ROBOFLOW_API_KEY
-```
-
-For persistence, add the `export` to your shell profile (`~/.zshrc`, `~/.bashrc`) or to a project-local `.env` file loaded by your agent's environment. Per-project isolation is the safer default — keeps separate workspaces and billing accounts from leaking across projects.
-
 ## Install as a plugin
 
 The repo ships both plugin manifests pointing at the same skill content and MCP config:
@@ -33,21 +15,16 @@ Both manifests load skills from [`skills/`](skills/) and bundle the Roboflow MCP
 
 ### Claude Code
 
-Local development test (from a clone of this repo):
+Install from GitHub — no clone required:
 
 ```bash
-claude --plugin-dir .
-```
-
-This loads the plugin from the working tree without installing it — the right path for iterating on skill content or verifying a fork.
-
-Marketplace install (once published):
-
-```bash
+claude plugin marketplace add roboflow/computer-vision-skills
 claude plugin install roboflow
 ```
 
-By default plugins install at user scope (available across all projects). For per-project isolation — for example, when different projects need different `ROBOFLOW_API_KEY` values for different workspaces — install at local scope:
+The first command registers this repo as a marketplace source (run once per machine). The second installs the plugin.
+
+For per-project isolation — for example, when different projects need different `ROBOFLOW_API_KEY` values for different workspaces:
 
 ```bash
 claude plugin install roboflow --scope local
@@ -55,9 +32,32 @@ claude plugin install roboflow --scope local
 
 Local scope writes the plugin into the current project only and reads the API key from that project's environment.
 
+**Alternative** — install from a local clone:
+
+```bash
+git clone https://github.com/roboflow/computer-vision-skills
+claude plugin marketplace add ./computer-vision-skills
+claude plugin install roboflow
+```
+
+For a throwaway test without touching the installed-plugins list:
+
+```bash
+cd computer-vision-skills
+claude --plugin-dir .
+```
+
 ### Codex
 
-Local development test:
+Install from a local clone:
+
+```bash
+git clone https://github.com/roboflow/computer-vision-skills
+cd computer-vision-skills
+codex plugin install .
+```
+
+For a throwaway test without touching the installed-plugins list:
 
 ```bash
 codex --plugin-dir .
@@ -101,13 +101,34 @@ The `npx skills` CLI works with any agent that reads `SKILL.md` files from `.cla
 
 ## MCP and skills
 
-The [Roboflow MCP server](https://mcp.roboflow.com/) should expose live tools for projects, images, annotations, versions, models, Workflows, Universe, and feedback. This plugin should own the expert guidance in skills.
+The [Roboflow MCP server](https://mcp.roboflow.com/) exposes live tools for projects, images, annotations, versions, models, Workflows, Universe, and feedback. Skills own the expert guidance and workflow playbooks.
 
 That separation keeps the install model simple:
 
 - MCP server: live Roboflow tools and authenticated API access
 - Plugin skills: durable product guidance and workflow playbooks
 - This repo: canonical source for skill updates and plugin distribution
+
+<details>
+<summary>Get your API key</summary>
+
+Grab your Roboflow API key from the workspace settings page:
+
+```text
+https://app.roboflow.com/{workspace}/settings/api
+```
+
+Replace `{workspace}` with your workspace slug. The key authenticates the bundled MCP server against `https://mcp.roboflow.com/mcp` via the `x-api-key` header.
+
+Export it in the shell that launches your agent:
+
+```bash
+export ROBOFLOW_API_KEY=YOUR_ROBOFLOW_API_KEY
+```
+
+For persistence, add the `export` to your shell profile (`~/.zshrc`, `~/.bashrc`) or to a project-local `.env` file loaded by your agent's environment. Per-project isolation is the safer default — keeps separate workspaces and billing accounts from leaking across projects.
+
+</details>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,32 +4,76 @@ Agent-ready Roboflow skills plus MCP configuration for computer vision workflows
 
 This repository is a plugin-shaped source of truth for AI agents (Claude Code, Codex, Cursor, OpenCode, and others). The canonical skill content lives in [`skills/`](skills/); plugin manifests point at those files instead of copying them elsewhere.
 
-## Install as a plugin
+## Get your API key
 
-The repo includes both plugin manifests:
+Grab your Roboflow API key from the workspace settings page:
 
-- Codex: [`.codex-plugin/plugin.json`](.codex-plugin/plugin.json)
-- Claude Code: [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json)
+```text
+https://app.roboflow.com/{workspace}/settings/api
+```
 
-Both manifests load skills from [`skills/`](skills/) and bundle the Roboflow MCP server config from [`.mcp.json`](.mcp.json).
+Replace `{workspace}` with your workspace slug. The key authenticates the bundled MCP server against `https://mcp.roboflow.com/mcp` via the `x-api-key` header.
 
-Set your Roboflow API key in the environment used by your agent before enabling the plugin:
+Export it in the shell that launches your agent:
 
 ```bash
 export ROBOFLOW_API_KEY=YOUR_ROBOFLOW_API_KEY
 ```
 
-The bundled MCP server connects to `https://mcp.roboflow.com/mcp` and sends the API key as the `x-api-key` header.
+For persistence, add the `export` to your shell profile (`~/.zshrc`, `~/.bashrc`) or to a project-local `.env` file loaded by your agent's environment. Per-project isolation is the safer default — keeps separate workspaces and billing accounts from leaking across projects.
 
-For local Claude Code plugin testing:
+## Install as a plugin
+
+The repo ships both plugin manifests pointing at the same skill content and MCP config:
+
+- Claude Code: [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) — plugin name `roboflow`
+- Codex: [`.codex-plugin/plugin.json`](.codex-plugin/plugin.json) — plugin name `roboflow`
+
+Both manifests load skills from [`skills/`](skills/) and bundle the Roboflow MCP server config from [`.mcp.json`](.mcp.json).
+
+### Claude Code
+
+Local development test (from a clone of this repo):
 
 ```bash
 claude --plugin-dir .
 ```
 
+This loads the plugin from the working tree without installing it — the right path for iterating on skill content or verifying a fork.
+
+Marketplace install (once published):
+
+```bash
+claude plugin install roboflow
+```
+
+By default plugins install at user scope (available across all projects). For per-project isolation — for example, when different projects need different `ROBOFLOW_API_KEY` values for different workspaces — install at local scope:
+
+```bash
+claude plugin install roboflow --scope local
+```
+
+Local scope writes the plugin into the current project only and reads the API key from that project's environment.
+
+### Codex
+
+Local development test:
+
+```bash
+codex --plugin-dir .
+```
+
+Marketplace install (once published):
+
+```bash
+codex plugin install roboflow
+```
+
+Codex picks up `ROBOFLOW_API_KEY` from the same shell environment that launches the `codex` binary. Use a project-scoped `.env` if you need different keys per project.
+
 ## Install standalone skills
 
-Install all skills:
+If you want the skills without the MCP server bundle — for example, with an agent that doesn't speak the plugin manifest format — install them directly:
 
 ```bash
 npx skills add roboflow/computer-vision-skills
@@ -43,7 +87,7 @@ npx skills add roboflow/computer-vision-skills --skill inference
 
 By default this installs into `./.claude/skills/` for the current project. Pass `-g` for `~/.claude/skills/` (global).
 
-See [`vercel-labs/skills`](https://github.com/vercel-labs/skills) for the full CLI reference.
+The `npx skills` CLI works with any agent that reads `SKILL.md` files from `.claude/skills/` — Claude Code, Cursor, OpenCode, and others. See [`vercel-labs/skills`](https://github.com/vercel-labs/skills) for the full CLI reference.
 
 ## Available skills
 

--- a/skills/api-reference/SKILL.md
+++ b/skills/api-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roboflow-api-reference
-description: Reference for Roboflow REST API and Inference API — hosts (api.roboflow.com, serverless.roboflow.com, dedicated, localhost:9001), auth, and request/response formats.
+description: Use when looking up Roboflow REST or Inference API hosts, authentication patterns, SDK choice, or request/response formats; covers api.roboflow.com, serverless.roboflow.com, dedicated, and self-hosted localhost endpoints.
 ---
 
 > **Tip:** If you're connected to the [Roboflow MCP server](https://github.com/roboflow/roboflow-mcp), prefer its tools (`projects_*`, `versions_*`, `models_*`, `workflows_*`, `images_*`, …) over raw REST calls — they handle auth, pagination, and typed responses for you. The REST patterns below stay relevant if you're not using MCP.


### PR DESCRIPTION
- README: add "Get your API key" section; split plugin install into Claude Code and Codex subsections; cover --scope local isolation; clarify npx skills works without MCP bundle; add compatible-agents list
- skills/api-reference/SKILL.md: rewrite description from noun-phrase to "Use when..." trigger phrase consistent with all other skills
- .gitignore: add .idea/ entry
