### PR TITLE
Recommend WebRTC over InferencePipeline for video streaming

### DIFF
--- a/skills/api-reference/SKILL.md
+++ b/skills/api-reference/SKILL.md
@@ -76,6 +76,7 @@ result = model.predict("image.jpg", confidence=40).json()
 | Start training | `api.roboflow.com` |
 | High-throughput / SLA inference | Dedicated deployment URL |
 | Air-gapped / on-prem inference | Self-hosted `localhost:9001` |
+| Real-time video / webcam / RTSP | WebRTC via `inference_sdk.webrtc` against serverless or local — see `roboflow://skills/inference/workflows` ("Video Stream" section). Not a plain HTTP call. |
 
 ## Rate Limits
 

--- a/skills/api-reference/SKILL.md
+++ b/skills/api-reference/SKILL.md
@@ -3,6 +3,8 @@ name: roboflow-api-reference
 description: Protocol-level facts for Roboflow REST and Inference APIs — URL patterns, auth, parameters, error codes, and SDK quick-start. For deployment strategy and Workflow execution patterns, see roboflow-inference.
 ---
 
+> **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
+
 > **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), prefer its tools (`projects_*`, `versions_*`, `models_*`, `workflows_*`, `images_*`, …) over raw REST calls — they handle auth, pagination, and typed responses for you. The REST patterns below stay relevant if you're not using MCP.
 
 # Roboflow API Reference — Overview

--- a/skills/api-reference/inference.md
+++ b/skills/api-reference/inference.md
@@ -1,5 +1,7 @@
 # Roboflow Inference API Reference
 
+> **Source-of-truth note:** This page ships with the Roboflow plugin. If your client has the plugin loaded, prefer the local skill (`roboflow:api-reference`) over fetching `roboflow://skills/api-reference/inference` via `ReadMcpResourceTool` — the MCP resources are a fallback for non-plugin clients and may lag the source repo.
+
 > **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), prefer `models_infer` (single-model) or `workflow_specs_run` / `workflows_run` (chained pipelines with annotated images) over raw HTTP calls — same operations, but auth is handled and responses are typed. The REST patterns below stay relevant if you're not using MCP.
 
 ## Serverless Inference (Hosted API v2)

--- a/skills/api-reference/rest-api.md
+++ b/skills/api-reference/rest-api.md
@@ -1,5 +1,7 @@
 # Roboflow Platform REST API Reference
 
+> **Source-of-truth note:** This page ships with the Roboflow plugin. If your client has the plugin loaded, prefer the local skill (`roboflow:api-reference`) over fetching `roboflow://skills/api-reference/rest-api` via `ReadMcpResourceTool` — the MCP resources are a fallback for non-plugin clients and may lag the source repo.
+
 > **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), prefer its tools (`projects_*`, `versions_*`, `images_*`, `annotations_save`, `models_train`, …) over raw REST calls — they handle auth and typed responses for you. The REST patterns below stay relevant if you're not using MCP.
 
 Base URL: `https://api.roboflow.com`

--- a/skills/data-management/SKILL.md
+++ b/skills/data-management/SKILL.md
@@ -3,6 +3,8 @@ name: roboflow-data-management
 description: Use when uploading images, labeling, organizing datasets, creating Roboflow projects (detection/segmentation/keypoint/classification), tags, splits, versions, or RoboQL search.
 ---
 
+> **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
+
 # Data Management on Roboflow
 
 ## Project Types

--- a/skills/data-management/labeling.md
+++ b/skills/data-management/labeling.md
@@ -5,6 +5,8 @@ description: Annotation tools, AI labeling features (Label Assist, Smart Polygon
 
 # Labeling & Annotation on Roboflow
 
+> **Source-of-truth note:** This page ships with the Roboflow plugin. If your client has the plugin loaded, prefer the local skill (`roboflow:data-management`) over fetching `roboflow://skills/data-management/labeling` via `ReadMcpResourceTool` — the MCP resources are a fallback for non-plugin clients and may lag the source repo.
+
 ## Annotation Tools
 
 | Tool | Shortcut | Use Case |

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -3,6 +3,8 @@ name: roboflow-inference
 description: Deployment option comparison (serverless, dedicated, self-hosted, batch) and Workflow execution patterns. For raw API URL patterns, auth, and request/response formats, see roboflow-api-reference.
 ---
 
+> **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
+
 > **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), use its inference tools (`models_infer`, `workflow_specs_run`, `workflows_run`) directly — they cover the same operations as the HTTP endpoints below with auth handled. The HTTP patterns stay relevant if you're not using MCP.
 
 # Inference & Deployment

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -11,7 +11,7 @@ description: Deployment option comparison (serverless, dedicated, self-hosted, b
 
 > **Prefer Workflows over direct model inference.** Workflows let you chain model + visualization + logic blocks in one call via `workflow_specs_run`. Direct `models_infer` returns JSON only — no annotated images, and instance segmentation responses can be very large. See `roboflow://skills/inference/workflows` and `roboflow://skills/inference/workflow-templates`.
 
-> **For live video (webcam, RTSP, file): use WebRTC, not `InferencePipeline`.** The MCP `workflows_run` tool only handles single static images — that's expected, and **does not mean** you should fall back to `inference.InferencePipeline.init_with_workflow()` for live video. The recommended path for streaming workflows is the WebRTC API (`inference_sdk.webrtc`) against either serverless GPU or a local `inference server` (Docker / `inference server start`). See `roboflow://skills/inference/workflows` ("Video Stream" section) for full code. Reach for `InferencePipeline` only if the user has a specific reason to embed the loop in their own Python process.
+> **For live video (webcam, RTSP, file):** the MCP `workflows_run` tool only handles single static images. For live video, present the user with **three options** (don't pick one silently): **(A)** WebRTC → serverless GPU, **(B)** WebRTC → local `inference server`, or **(C)** in-process `InferencePipeline`. They have different setup costs, dep sizes, and latency characteristics — surface a brief 1-line summary of each and let the user choose. See `roboflow://skills/inference/workflows` ("Video Stream" section) for full code and the comparison table.
 
 ## Deployment Options
 
@@ -28,7 +28,11 @@ description: Deployment option comparison (serverless, dedicated, self-hosted, b
 - **Dedicated** -- need consistent latency, large models (Florence 2), or high throughput. Development and production tiers available. Subdomain: `<name>.roboflow.cloud`.
 - **Self-hosted** -- deploy Roboflow Inference via Docker on your own hardware (Jetson, cloud VMs, RPi). Same API surface as serverless -- just change `api_url`.
 - **Batch Processing** -- runs a Workflow on uploaded images/videos asynchronously. No real-time requirement. Results delivered as JSON.
-- **Real-time video (webcam/RTSP/file)** -- prefer the **WebRTC API** (`inference_sdk.webrtc`) against either serverless GPU or a local `inference server`. Ask the user which they want before generating code. `InferencePipeline.init_with_workflow()` is a lower-level alternative that runs the pipeline inside the user's Python process — only reach for it if they explicitly need that (e.g. tight in-process integration with their own code). For most cases WebRTC is easier: the inference server (Docker or `inference server start`) handles the heavy CV/model deps for you, whereas `InferencePipeline` requires installing the full `inference` package locally (torch, opencv, etc., which is fragile across environments). See `roboflow://skills/inference/workflows` ("Video Stream" section) for the recommended pattern.
+- **Real-time video (webcam/RTSP/file)** -- three deployment options; ask the user which one before writing code:
+  - **(A) Serverless GPU + WebRTC** — zero setup, just an API key; per-minute credits, plan-tiered (`webrtc-gpu-small/medium/large`).
+  - **(B) Local inference server + WebRTC** — `pip install inference-cli && inference server start` (Docker recommended); lowest latency, isolates the heavy CV/model deps inside the server.
+  - **(C) `InferencePipeline` in-process** — `pip install inference` in a venv (prefer `uv`); runs the workflow loop directly in the user's Python process, no separate server. Heavy deps (torch, opencv, onnxruntime) install locally; **first run is slow** (model download + ONNX warmup, typically 30–60s); subsequent runs are fast.
+  - See `roboflow://skills/inference/workflows` ("Video Stream" section) for full code and a comparison table.
 
 ## MCP Tools for Inference
 

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -24,6 +24,7 @@ description: Deployment option comparison (serverless, dedicated, self-hosted, b
 - **Dedicated** -- need consistent latency, large models (Florence 2), or high throughput. Development and production tiers available. Subdomain: `<name>.roboflow.cloud`.
 - **Self-hosted** -- deploy Roboflow Inference via Docker on your own hardware (Jetson, cloud VMs, RPi). Same API surface as serverless -- just change `api_url`.
 - **Batch Processing** -- runs a Workflow on uploaded images/videos asynchronously. No real-time requirement. Results delivered as JSON.
+- **Real-time video (webcam/RTSP/file)** -- prefer the **WebRTC API** (`inference_sdk.webrtc`) against either serverless GPU or a local `inference server`. Ask the user which they want before generating code. `InferencePipeline.init_with_workflow()` is a lower-level alternative that runs the pipeline inside the user's Python process — only reach for it if they explicitly need that (e.g. tight in-process integration with their own code). For most cases WebRTC is easier: the inference server (Docker or `inference server start`) handles the heavy CV/model deps for you, whereas `InferencePipeline` requires installing the full `inference` package locally (torch, opencv, etc., which is fragile across environments). See `roboflow://skills/inference/workflows` ("Video Stream" section) for the recommended pattern.
 
 ## MCP Tools for Inference
 

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -31,7 +31,9 @@ description: Deployment option comparison (serverless, dedicated, self-hosted, b
 - **Real-time video (webcam/RTSP/file)** -- three deployment options; ask the user which one before writing code:
   - **(A) Serverless GPU + WebRTC** — zero setup, just an API key; per-minute credits, plan-tiered (`webrtc-gpu-small/medium/large`).
   - **(B) Local inference server + WebRTC** — `pip install inference-cli && inference server start` (Docker recommended); lowest latency, isolates the heavy CV/model deps inside the server.
-  - **(C) `InferencePipeline` in-process** — `pip install inference` in a venv (prefer `uv`); runs the workflow loop directly in the user's Python process, no separate server. Heavy deps (torch, opencv, onnxruntime) install locally; **first run is slow** (model download + ONNX warmup, typically 30–60s); subsequent runs are fast.
+  - **(C) `InferencePipeline` in-process** — `pip install inference` in a venv (prefer `uv`); runs the workflow loop directly in the user's Python process, no separate server. Heavy deps (torch, opencv, onnxruntime) install locally.
+
+  All three have a slower first run (model download / warmup) before subsequent runs hit cached state — tell the user this so they don't think the script is hung.
   - See `roboflow://skills/inference/workflows` ("Video Stream" section) for full code and a comparison table.
 
 ## MCP Tools for Inference

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -9,6 +9,8 @@ description: Deployment option comparison (serverless, dedicated, self-hosted, b
 
 > **Prefer Workflows over direct model inference.** Workflows let you chain model + visualization + logic blocks in one call via `workflow_specs_run`. Direct `models_infer` returns JSON only — no annotated images, and instance segmentation responses can be very large. See `roboflow://skills/inference/workflows` and `roboflow://skills/inference/workflow-templates`.
 
+> **For live video (webcam, RTSP, file): use WebRTC, not `InferencePipeline`.** The MCP `workflows_run` tool only handles single static images — that's expected, and **does not mean** you should fall back to `inference.InferencePipeline.init_with_workflow()` for live video. The recommended path for streaming workflows is the WebRTC API (`inference_sdk.webrtc`) against either serverless GPU or a local `inference server` (Docker / `inference server start`). See `roboflow://skills/inference/workflows` ("Video Stream" section) for full code. Reach for `InferencePipeline` only if the user has a specific reason to embed the loop in their own Python process.
+
 ## Deployment Options
 
 | Option | Best For | Latency | Scaling | Cost Model | GPU |

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -17,7 +17,7 @@ description: Deployment option comparison (serverless, dedicated, self-hosted, b
 |--------|----------|---------|---------|------------|-----|
 | **Serverless** | Getting started, variable traffic | Low | Auto | Per-inference credit | Yes |
 | **Dedicated** | Predictable workloads, low latency | Very low | Manual/autoscale | Per-hour credits | Optional |
-| **Self-hosted** | Full control, edge, air-gapped | Hardware-dependent | Manual | Your infra cost | Optional |
+| **Self-hosted** | Full control, edge | Hardware-dependent | Manual | Metered + infra cost | Optional |
 | **Batch Processing** | Large offline datasets, videos | Async (minutes-hours) | Auto-provisioned | Per-job | Optional |
 
 ### When to Use Which

--- a/skills/inference/workflow-templates.md
+++ b/skills/inference/workflow-templates.md
@@ -1,5 +1,7 @@
 # Workflow Templates
 
+> **Source-of-truth note:** This page ships with the Roboflow plugin. If your client has the plugin loaded, prefer the local skill (`roboflow:inference`) over fetching `roboflow://skills/inference/workflow-templates` via `ReadMcpResourceTool` — the MCP resources are a fallback for non-plugin clients and may lag the source repo.
+
 Quick-reference catalog of built-in workflow templates. Use these as starting points when building workflows via the editor or `workflow_specs_run`.
 
 ## Detection & Counting

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -203,7 +203,7 @@ Pick `data_output` to match the **workflow output names** the user's workflow ex
 
 #### Variant B — Local inference server
 
-Best for: predictable latency on local GPU/CPU, no per-inference cost, air-gapped or edge.
+Best for: predictable latency on local GPU/CPU.
 
 Prereqs — start the inference server first:
 
@@ -258,7 +258,7 @@ session.run()
 | | Serverless WebRTC | Local WebRTC |
 |---|---|---|
 | Setup | None — just an API key | `pip install inference-cli && inference server start` |
-| Cost | Per-minute credits (plan-tiered) | Your hardware |
+| Cost | Per-minute credits (plan-tiered) | Metered credits + your hardware |
 | Latency | Network + GPU; depends on `requested_region` | Local — usually lowest |
 | GPU | `webrtc-gpu-small/medium/large` | Whatever you have (CPU works for light models) |
 | Best for | Demos, bursty workloads, no local GPU | Edge, on-prem, sustained workloads |

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -152,7 +152,7 @@ result = client.run_workflow(
 
 For real-time video — webcam, RTSP, or file — use the **WebRTC API** in `inference_sdk.webrtc`. It opens a peer connection to either the serverless GPU fleet or a local `inference server`, streams frames up, and returns annotated frames + workflow data over the data channel.
 
-> **Reasoning trap to avoid:** the MCP `workflows_run` tool only handles single static images. That's expected — it does not mean you should fall back to `inference.InferencePipeline.init_with_workflow(...)` for live video. WebRTC is the recommended path for both serverless and local. `InferencePipeline` is the lower-level escape hatch (see "What about `InferencePipeline`?" below), not the default.
+> **Reasoning trap to avoid:** the MCP `workflows_run` tool only handles single static images. That's expected — it does not mean you should fall back to `InferencePipeline` as the default for live video. **WebRTC (Variants A or B below) is the default** because it isolates the heavy CV/model deps inside an inference server. `InferencePipeline` (Variant C) is a lower-level option for in-process Python embedding — pick it only when in-process execution is a specific requirement.
 
 > **Always ask the user: serverless or local?** before generating the script. The two variants differ only in `api_url` and a few `StreamConfig` fields, but the choice has cost/latency implications.
 
@@ -255,21 +255,55 @@ def on_data(data: dict, metadata: VideoMetadata):
 session.run()
 ```
 
-#### Choosing serverless vs local
+#### Variant C — `InferencePipeline` (in-process Python)
 
-| | Serverless WebRTC | Local WebRTC |
-|---|---|---|
-| Setup | None — just an API key | `pip install inference-cli && inference server start` |
-| Cost | Per-minute credits (plan-tiered) | Metered credits + your hardware |
-| Latency | Network + GPU; depends on `requested_region` | Local — usually lowest |
-| GPU | `webrtc-gpu-small/medium/large` | Whatever you have (CPU works for light models) |
-| Best for | Demos, bursty workloads, no local GPU | Edge, on-prem, sustained workloads |
+Best for: embedding the workflow loop directly in your own Python application, single-host setups where standing up a separate inference server (Variant B) is overkill, or environments where you can't expose an HTTP/WebRTC port. The pipeline runs **in-process** — predictions are delivered to a callback in your script, not over a network channel.
 
-#### What about `InferencePipeline`?
+Trade-off: requires installing the full `inference` Python package locally, which pulls in heavy CV/model dependencies (torch, opencv, model files, etc.). On GPU especially, this is the most fragile install of the three options. If you can run the inference server (Variant B), prefer that — same model deps, but isolated. Reach for `InferencePipeline` only when in-process execution is a hard requirement and the user has confirmed they're OK installing the `inference` package locally.
 
-`inference.InferencePipeline.init_with_workflow(...)` is the **lower-level** alternative: it runs the workflow loop inline in the user's Python process instead of brokering through an inference server. Only reach for it when the user has a clear reason to need in-process execution — e.g. they want to interleave workflow output with their own per-frame Python code, embed in a custom app, or run somewhere they can't expose an HTTP/WebRTC port.
+```bash
+pip install inference                # CPU; or `inference-gpu` for CUDA
+```
 
-The trade-off: `InferencePipeline` requires installing the full `inference` package locally (torch, opencv, model deps), which is significantly harder to get right across environments than running the inference server via Docker or `inference server start`. For default webcam/RTSP/file cases, WebRTC is the right answer.
+```python
+import cv2
+from inference import InferencePipeline
+
+
+def on_prediction(result, video_frame):
+    # `result` is a dict of workflow outputs — pull whatever your workflow exposes.
+    if (annotated := result.get("annotated_image")) is not None:
+        cv2.imshow("Workflow Output", annotated.numpy_image)
+        cv2.waitKey(1)
+    if (count := result.get("active_count")) is not None:
+        print(f"active_count = {count}")
+
+
+pipeline = InferencePipeline.init_with_workflow(
+    api_key="YOUR_API_KEY",
+    workspace_name="my-workspace",
+    workflow_id="my-workflow-id",
+    video_reference=0,                # 0 = default webcam; can be RTSP URL or file path
+    image_input_name="image",         # name of the workflow's image input (default "image")
+    on_prediction=on_prediction,
+)
+
+pipeline.start()
+pipeline.join()                       # blocks until video source ends or pipeline terminates
+```
+
+#### Choosing among the three
+
+| | Serverless WebRTC (A) | Local WebRTC (B) | InferencePipeline (C) |
+|---|---|---|---|
+| Setup | None — just an API key | `pip install inference-cli && inference server start` | `pip install inference` (heavy deps: torch, opencv, …) |
+| Cost | Per-minute credits (plan-tiered) | Metered credits + your hardware | Metered credits + your hardware |
+| Latency | Network + GPU; depends on `requested_region` | Local — usually lowest | Local — equivalent to Variant B |
+| GPU | `webrtc-gpu-small/medium/large` | Whatever you have (CPU works for light models) | Whatever you have |
+| Process model | Separate session, frames over WebRTC | Separate server, frames over WebRTC | In-process: workflow runs in your Python script |
+| Best for | Demos, bursty workloads, no local GPU | Edge, on-prem, sustained workloads | Embedding in your own app; no HTTP/WebRTC port available |
+
+**Default order to recommend:** A (serverless) → B (local server) → C (in-process). Only suggest C when the user explicitly wants in-process execution or rules out the server-based options.
 
 ## When to Use Workflows vs Direct Inference
 

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -156,6 +156,8 @@ For real-time video — webcam, RTSP, or file — use the **WebRTC API** in `inf
 
 > **Always ask the user which variant** before generating the script. There are three: **(A)** serverless WebRTC, **(B)** local-server WebRTC, **(C)** in-process `InferencePipeline`. Surface a brief 1-line summary of each from the comparison table below — don't silently pick one. Variants A and B differ only in `api_url` and a few `StreamConfig` fields; Variant C is structurally different (in-process Python, no network).
 
+> **Tell the user: first run is slower than subsequent runs** for any of these — there's a model load / warmup step before the first frame is processed. Subsequent runs reuse cached state. Useful to mention so they don't think the script is hung when nothing happens for a few seconds.
+
 #### Variant A — Serverless GPU (hosted)
 
 Best for: zero infra setup, bursty/occasional use, getting started.
@@ -274,7 +276,7 @@ uv pip install inference                  # CPU; or `inference-gpu` for CUDA
 # python3.12 -m venv .venv && .venv/bin/pip install inference
 ```
 
-> **Heads-up to give the user before running:** the **first invocation is slow** — `inference` downloads model weights and warms up the ONNX runtime backend on first frame, typically 30–60 seconds before the webcam window opens. Subsequent runs reuse cached weights and start in a few seconds. Tell the user this so they don't think the script is hung. If they kill it during the first warmup, the next run starts over.
+> **First run is slower than subsequent runs** — `inference` downloads model weights and warms up the ONNX runtime on first invocation. Tell the user this so they don't think the script is hung. Subsequent runs reuse cached weights.
 
 ```python
 import cv2
@@ -313,7 +315,7 @@ pipeline.join()                       # blocks until video source ends or pipeli
 | GPU | `webrtc-gpu-small/medium/large` | Whatever you have (CPU works for light models) | Whatever you have |
 | Process model | Separate session, frames over WebRTC | Separate server, frames over WebRTC | In-process: workflow runs in your Python script |
 | Best for | Demos, bursty workloads, no local GPU | Edge, on-prem, sustained workloads | Single-host scripts, embedding in your own Python app, no HTTP/WebRTC port available |
-| First-run cost | Network handshake (~seconds) | Server start + model load (~10–30s if Docker image needs pulling) | Slow — model download + ONNX warmup, often 30–60s before first frame |
+| First run | Slower than subsequent — session handshake + model load on the assigned worker | Slower than subsequent — Docker image pull (if cold) and model load on first call | Slower than subsequent — model download + ONNX warmup |
 
 **How to present this to the user:** surface all three with a one-line summary of each (use the "Best for" row), then let the user pick. Don't default-pick; the right answer depends on whether they have Docker, want zero local install, or want the script to be self-contained.
 

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -154,7 +154,7 @@ For real-time video — webcam, RTSP, or file — use the **WebRTC API** in `inf
 
 > **Reasoning trap to avoid:** the MCP `workflows_run` tool only handles single static images. That's expected — it does not mean you should fall back to `InferencePipeline` as the default for live video. **WebRTC (Variants A or B below) is the default** because it isolates the heavy CV/model deps inside an inference server. `InferencePipeline` (Variant C) is a lower-level option for in-process Python embedding — pick it only when in-process execution is a specific requirement.
 
-> **Always ask the user: serverless or local?** before generating the script. The two variants differ only in `api_url` and a few `StreamConfig` fields, but the choice has cost/latency implications.
+> **Always ask the user which variant** before generating the script. There are three: **(A)** serverless WebRTC, **(B)** local-server WebRTC, **(C)** in-process `InferencePipeline`. Surface a brief 1-line summary of each from the comparison table below — don't silently pick one. Variants A and B differ only in `api_url` and a few `StreamConfig` fields; Variant C is structurally different (in-process Python, no network).
 
 #### Variant A — Serverless GPU (hosted)
 
@@ -259,11 +259,22 @@ session.run()
 
 Best for: embedding the workflow loop directly in your own Python application, single-host setups where standing up a separate inference server (Variant B) is overkill, or environments where you can't expose an HTTP/WebRTC port. The pipeline runs **in-process** — predictions are delivered to a callback in your script, not over a network channel.
 
-Trade-off: requires installing the full `inference` Python package locally, which pulls in heavy CV/model dependencies (torch, opencv, model files, etc.). On GPU especially, this is the most fragile install of the three options. If you can run the inference server (Variant B), prefer that — same model deps, but isolated. Reach for `InferencePipeline` only when in-process execution is a hard requirement and the user has confirmed they're OK installing the `inference` package locally.
+Trade-off: requires installing the full `inference` Python package locally, which pulls in heavy CV/model dependencies (torch, opencv, onnxruntime, model files, etc.). On GPU especially, this is the most fragile install of the three options. If you can run the inference server (Variant B), prefer that — same model deps, but isolated. Reach for `InferencePipeline` only when in-process execution is a hard requirement and the user has confirmed they're OK installing the `inference` package locally.
+
+**Setup — prefer `uv` for the venv, and pin Python to 3.12:**
 
 ```bash
-pip install inference                # CPU; or `inference-gpu` for CUDA
+# Preferred: uv is much faster and keeps deps in an isolated venv.
+# Pin Python to 3.12 — newer versions (3.13+) often lack onnxruntime wheels,
+# so `uv pip install inference` will fail on a default-Python (3.13+) venv.
+uv venv --python 3.12
+uv pip install inference                  # CPU; or `inference-gpu` for CUDA
+
+# Without uv, fall back to stdlib venv (slower, but works):
+# python3.12 -m venv .venv && .venv/bin/pip install inference
 ```
+
+> **Heads-up to give the user before running:** the **first invocation is slow** — `inference` downloads model weights and warms up the ONNX runtime backend on first frame, typically 30–60 seconds before the webcam window opens. Subsequent runs reuse cached weights and start in a few seconds. Tell the user this so they don't think the script is hung. If they kill it during the first warmup, the next run starts over.
 
 ```python
 import cv2
@@ -301,9 +312,10 @@ pipeline.join()                       # blocks until video source ends or pipeli
 | Latency | Network + GPU; depends on `requested_region` | Local — usually lowest | Local — equivalent to Variant B |
 | GPU | `webrtc-gpu-small/medium/large` | Whatever you have (CPU works for light models) | Whatever you have |
 | Process model | Separate session, frames over WebRTC | Separate server, frames over WebRTC | In-process: workflow runs in your Python script |
-| Best for | Demos, bursty workloads, no local GPU | Edge, on-prem, sustained workloads | Embedding in your own app; no HTTP/WebRTC port available |
+| Best for | Demos, bursty workloads, no local GPU | Edge, on-prem, sustained workloads | Single-host scripts, embedding in your own Python app, no HTTP/WebRTC port available |
+| First-run cost | Network handshake (~seconds) | Server start + model load (~10–30s if Docker image needs pulling) | Slow — model download + ONNX warmup, often 30–60s before first frame |
 
-**Default order to recommend:** A (serverless) → B (local server) → C (in-process). Only suggest C when the user explicitly wants in-process execution or rules out the server-based options.
+**How to present this to the user:** surface all three with a one-line summary of each (use the "Best for" row), then let the user pick. Don't default-pick; the right answer depends on whether they have Docker, want zero local install, or want the script to be self-contained.
 
 ## When to Use Workflows vs Direct Inference
 

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -150,6 +150,8 @@ result = client.run_workflow(
 
 For real-time video — webcam, RTSP, or file — use the **WebRTC API** in `inference_sdk.webrtc`. It opens a peer connection to either the serverless GPU fleet or a local `inference server`, streams frames up, and returns annotated frames + workflow data over the data channel.
 
+> **Reasoning trap to avoid:** the MCP `workflows_run` tool only handles single static images. That's expected — it does not mean you should fall back to `inference.InferencePipeline.init_with_workflow(...)` for live video. WebRTC is the recommended path for both serverless and local. `InferencePipeline` is the lower-level escape hatch (see "What about `InferencePipeline`?" below), not the default.
+
 > **Always ask the user: serverless or local?** before generating the script. The two variants differ only in `api_url` and a few `StreamConfig` fields, but the choice has cost/latency implications.
 
 #### Variant A — Serverless GPU (hosted)

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -1,5 +1,7 @@
 # Workflows
 
+> **Source-of-truth note:** This page ships with the Roboflow plugin. If your client has the plugin loaded, prefer the local skill (`roboflow:inference`) over fetching `roboflow://skills/inference/workflows` via `ReadMcpResourceTool` — the MCP resources are a fallback for non-plugin clients and may lag the source repo.
+
 > **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), use `workflow_specs_run` (run a spec ad-hoc) or `workflows_run` (run a saved workflow) instead of raw HTTP — they return annotated images alongside JSON. The HTTP patterns stay relevant if you're not using MCP.
 
 ## What Are Workflows

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -128,7 +128,7 @@ Step names: derive from block type, strip `roboflow_core/` and `@vX`, lowercase 
 | **Serverless API** | `workflows_run` MCP tool or `client.run_workflow()` SDK |
 | **Dedicated** | Point at `<name>.roboflow.cloud` endpoint |
 | **Self-hosted** | `inference server start`, use `api_url="http://localhost:9001"` |
-| **Video/Stream** | `InferencePipeline.init_with_workflow()` with RTSP/webcam/file |
+| **Video/Stream (webcam, RTSP, file)** | WebRTC via `inference_sdk.webrtc` — runs on serverless GPU or your local inference server (see "Video Stream" below). Prefer this over `InferencePipeline`, which is a lower-level in-process alternative that requires installing the full `inference` package (torch/opencv/etc.) locally. |
 
 ### SDK Code
 
@@ -146,21 +146,126 @@ result = client.run_workflow(
 )
 ```
 
-### Video Stream
+### Video Stream (Webcam / RTSP / File) — WebRTC
+
+For real-time video — webcam, RTSP, or file — use the **WebRTC API** in `inference_sdk.webrtc`. It opens a peer connection to either the serverless GPU fleet or a local `inference server`, streams frames up, and returns annotated frames + workflow data over the data channel.
+
+> **Always ask the user: serverless or local?** before generating the script. The two variants differ only in `api_url` and a few `StreamConfig` fields, but the choice has cost/latency implications.
+
+#### Variant A — Serverless GPU (hosted)
+
+Best for: zero infra setup, bursty/occasional use, getting started.
 
 ```python
-from inference import InferencePipeline
+import cv2
+from inference_sdk import InferenceHTTPClient
+from inference_sdk.webrtc import WebcamSource, StreamConfig, VideoMetadata
 
-pipeline = InferencePipeline.init_with_workflow(
-    api_key="API_KEY",
-    workspace_name="workspace-name",
-    workflow_id="workflow-id",
-    video_reference=0,  # webcam, RTSP URL, or file path
-    on_prediction=lambda result, frame: print(result)
+client = InferenceHTTPClient.init(
+    api_url="https://serverless.roboflow.com",
+    api_key="YOUR_API_KEY",
 )
-pipeline.start()
-pipeline.join()
+
+source = WebcamSource(resolution=(1280, 720))  # or RTSPSource / FileSource
+
+config = StreamConfig(
+    stream_output=["annotated_image"],          # frames returned to client
+    data_output=["active_count", "new_instances", "event_log", "complete_events"],  # workflow outputs over datachannel
+    processing_timeout=3600,                    # seconds; session ends after this
+    requested_plan="webrtc-gpu-medium",         # webrtc-gpu-small | webrtc-gpu-medium | webrtc-gpu-large
+    requested_region="us",                      # us | eu | ap
+)
+
+session = client.webrtc.stream(
+    source=source,
+    workflow="my-workflow-id",
+    workspace="my-workspace",
+    image_input="image",                        # name of the image input on the workflow
+    config=config,
+)
+
+@session.on_frame
+def show_frame(frame, metadata: VideoMetadata):
+    cv2.imshow("Workflow Output", frame)
+    if cv2.waitKey(1) & 0xFF == ord("q"):
+        session.close()
+
+@session.on_data()
+def on_data(data: dict, metadata: VideoMetadata):
+    print(f"Frame {metadata.frame_id}: {data}")
+
+session.run()  # blocks until the session closes
 ```
+
+Pick `data_output` to match the **workflow output names** the user's workflow exposes (e.g. counts, event logs, tracking ids). Look these up via `workflows_get` if unsure.
+
+#### Variant B — Local inference server
+
+Best for: predictable latency on local GPU/CPU, no per-inference cost, air-gapped or edge.
+
+Prereqs — start the inference server first:
+
+```bash
+pip install inference                # or: pip install inference-gpu
+inference server start               # serves on http://localhost:9001
+```
+
+Then the same script with two changes: `api_url` points at localhost, and `StreamConfig` drops `requested_plan` / `requested_region` (those are serverless-only).
+
+```python
+import cv2
+from inference_sdk import InferenceHTTPClient
+from inference_sdk.webrtc import WebcamSource, StreamConfig, VideoMetadata
+
+client = InferenceHTTPClient.init(
+    api_url="http://localhost:9001",
+    api_key="YOUR_API_KEY",
+)
+
+source = WebcamSource(resolution=(1280, 720))
+
+config = StreamConfig(
+    stream_output=["annotated_image"],
+    data_output=["active_count", "new_instances", "event_log", "complete_events"],
+    processing_timeout=3600,
+)
+
+session = client.webrtc.stream(
+    source=source,
+    workflow="my-workflow-id",
+    workspace="my-workspace",
+    image_input="image",
+    config=config,
+)
+
+@session.on_frame
+def show_frame(frame, metadata: VideoMetadata):
+    cv2.imshow("Workflow Output", frame)
+    if cv2.waitKey(1) & 0xFF == ord("q"):
+        session.close()
+
+@session.on_data()
+def on_data(data: dict, metadata: VideoMetadata):
+    print(f"Frame {metadata.frame_id}: {data}")
+
+session.run()
+```
+
+#### Choosing serverless vs local
+
+| | Serverless WebRTC | Local WebRTC |
+|---|---|---|
+| Setup | None — just an API key | `pip install inference` + `inference server start` |
+| Cost | Per-minute credits (plan-tiered) | Your hardware |
+| Latency | Network + GPU; depends on `requested_region` | Local — usually lowest |
+| GPU | `webrtc-gpu-small/medium/large` | Whatever you have (CPU works for light models) |
+| Best for | Demos, bursty workloads, no local GPU | Edge, on-prem, sustained workloads |
+
+#### What about `InferencePipeline`?
+
+`inference.InferencePipeline.init_with_workflow(...)` is the **lower-level** alternative: it runs the workflow loop inline in the user's Python process instead of brokering through an inference server. Only reach for it when the user has a clear reason to need in-process execution — e.g. they want to interleave workflow output with their own per-frame Python code, embed in a custom app, or run somewhere they can't expose an HTTP/WebRTC port.
+
+The trade-off: `InferencePipeline` requires installing the full `inference` package locally (torch, opencv, model deps), which is significantly harder to get right across environments than running the inference server via Docker or `inference server start`. For default webcam/RTSP/file cases, WebRTC is the right answer.
 
 ## When to Use Workflows vs Direct Inference
 

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -208,8 +208,8 @@ Best for: predictable latency on local GPU/CPU, no per-inference cost, air-gappe
 Prereqs — start the inference server first:
 
 ```bash
-pip install inference                # or: pip install inference-gpu
-inference server start               # serves on http://localhost:9001
+pip install inference-cli
+inference server start     # serves inference server on http://localhost:9001
 ```
 
 Then the same script with two changes: `api_url` points at localhost, and `StreamConfig` drops `requested_plan` / `requested_region` (those are serverless-only).
@@ -257,7 +257,7 @@ session.run()
 
 | | Serverless WebRTC | Local WebRTC |
 |---|---|---|
-| Setup | None — just an API key | `pip install inference` + `inference server start` |
+| Setup | None — just an API key | `pip install inference-cli && inference server start` |
 | Cost | Per-minute credits (plan-tiered) | Your hardware |
 | Latency | Network + GPU; depends on `requested_region` | Local — usually lowest |
 | GPU | `webrtc-gpu-small/medium/large` | Whatever you have (CPU works for light models) |

--- a/skills/plans-and-pricing/SKILL.md
+++ b/skills/plans-and-pricing/SKILL.md
@@ -38,7 +38,6 @@ Extra credits: prepaid packs ($130–$630/mo) or flex at $6/credit overage. Deta
 
 | Action | 1 Credit = |
 |--------|-----------|
-| Hosted API (v1) | 1,000 inferences |
 | Hosted API (v2) | 500 seconds execution |
 | Video streams (CPU) | 10 hours |
 | Video streams (GPU — small) | 80 minutes |
@@ -75,15 +74,8 @@ When helping users estimate costs:
 2. Direct the user to `roboflow.com/pricing` for current credit pricing per plan
 3. Recommend the right deployment option:
    - **Low volume / getting started** → Serverless (simplest, pay-per-use)
-   - **High volume / continuous** → Self-hosted via `pip install inference` (same API, no per-inference cost, just hardware)
+   - **High volume / continuous** → Self-hosted via inference server/inference-sdk (same API)
    - **Predictable production load** → Dedicated deployment (consistent latency, per-hour)
-
-### Example: Continuous Video (1 fps × 12h/day)
-
-- 43,200 frames/day → ~1.3M frames/month
-- Serverless: ~1,300 credits/month
-- Self-hosted: same model + API, runs on any box with `pip install inference`. Cost = hardware only.
-- For always-on use cases, self-hosted almost always wins.
 
 ## Where to Check
 

--- a/skills/plans-and-pricing/SKILL.md
+++ b/skills/plans-and-pricing/SKILL.md
@@ -3,6 +3,8 @@ name: roboflow-plans-and-pricing
 description: Use when answering questions about Roboflow plans, credit usage, or cost estimation; directs users to roboflow.com/pricing for current dollar amounts.
 ---
 
+> **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
+
 # Plans & Pricing
 
 For current dollar pricing, always direct the user to `roboflow.com/pricing`. Never guess at prices.

--- a/skills/product-navigation/SKILL.md
+++ b/skills/product-navigation/SKILL.md
@@ -3,6 +3,8 @@ name: roboflow-product-navigation
 description: Use when explaining where Roboflow features live in the app.roboflow.com web app, mapping intents like upload, annotate, train, deploy to specific page URLs.
 ---
 
+> **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
+
 # Roboflow Web App Navigation
 
 Base URL: `https://app.roboflow.com`

--- a/skills/product-navigation/features-by-page.md
+++ b/skills/product-navigation/features-by-page.md
@@ -1,5 +1,7 @@
 # Roboflow: Feature Lookup by Intent
 
+> **Source-of-truth note:** This page ships with the Roboflow plugin. If your client has the plugin loaded, prefer the local skill (`roboflow:product-navigation`) over fetching `roboflow://skills/product-navigation/features-by-page` via `ReadMcpResourceTool` — the MCP resources are a fallback for non-plugin clients and may lag the source repo.
+
 "I want to do X" -> go here / use this tool.
 
 Base URL: `https://app.roboflow.com`

--- a/skills/training-and-evaluation/SKILL.md
+++ b/skills/training-and-evaluation/SKILL.md
@@ -3,6 +3,8 @@ name: roboflow-training-and-evaluation
 description: Use when training Roboflow models or improving accuracy - covers architecture selection, model IDs, checkpoints, evaluation metrics, and the iterative improvement playbook.
 ---
 
+> **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
+
 # Training & Evaluation on Roboflow
 
 ## Training Flow

--- a/skills/training-and-evaluation/improvement-playbook.md
+++ b/skills/training-and-evaluation/improvement-playbook.md
@@ -5,6 +5,8 @@ description: Diagnostic playbook for improving trained model accuracy — confus
 
 # Model Improvement Playbook
 
+> **Source-of-truth note:** This page ships with the Roboflow plugin. If your client has the plugin loaded, prefer the local skill (`roboflow:training-and-evaluation`) over fetching `roboflow://skills/training-and-evaluation/improvement-playbook` via `ReadMcpResourceTool` — the MCP resources are a fallback for non-plugin clients and may lag the source repo.
+
 ## Diagnostic Decision Tree
 
 ```

--- a/skills/universe/SKILL.md
+++ b/skills/universe/SKILL.md
@@ -3,6 +3,8 @@ name: roboflow-universe
 description: Use when searching for or using public datasets/models on Roboflow Universe (universe.roboflow.com), the open repository of 1M+ computer vision datasets and 50K+ pre-trained models.
 ---
 
+> **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
+
 # Roboflow Universe
 
 Open repository of 1M+ computer vision datasets and 50K+ pre-trained models at `universe.roboflow.com`.


### PR DESCRIPTION
## Summary

Webcam/RTSP/file workflows should use the **WebRTC API** (`inference_sdk.webrtc`) against either serverless GPU or a local `inference server` — not `InferencePipeline.init_with_workflow()`. The previous "Video Stream" snippet led the plugin to generate scripts that pull in the full `inference` package (torch, opencv, model deps), which is fragile to install vs. just running the inference server via Docker or `inference server start`.

## Context

Surfaced from a real plugin session ([log](https://github.com/anthropics/claude-code/blob/main/) — local at `~/.claude/projects/-private-tmp-example/4c9d0906-37d3-4a4b-9045-c95635f36c3e.jsonl`) where the agent picked the `InferencePipeline` path because that's what `inference/workflows.md` recommended. Two issues with that:

1. WebRTC is the recommended surface for real-time video — same API works against serverless GPU (`webrtc-gpu-small/medium/large`, region-pinnable) or local (`http://localhost:9001`).
2. The agent didn't ask serverless-vs-local; the two paths differ enough (cost, latency, plan/region config) that the user should choose.

## Changes

- **`skills/inference/workflows.md`** — replaced the "Video Stream" code block with two full WebRTC examples (serverless + local), a serverless-vs-local comparison table, and a trailing **"What about `InferencePipeline`?"** section positioning it as the lower-level escape hatch (when you specifically need in-process Python execution and accept the heavier dep install).
- **`skills/inference/SKILL.md`** — added a "Real-time video (webcam/RTSP/file)" bullet to the deployment-options list, instructing the agent to ask serverless-vs-local before generating code.
- **`skills/api-reference/SKILL.md`** — added a Host Selection Guide row routing webcam/RTSP queries to the workflows doc (so an agent landing in api-reference doesn't try to wedge streaming into raw HTTP).

## Test plan

- [ ] Re-run the plugin against the original "I have a workflow on Roboflow I want to run with my webcam" prompt and confirm the agent (a) asks serverless-vs-local and (b) generates a `inference_sdk.webrtc` script, not an `InferencePipeline` one.
- [ ] Confirm the local-variant script runs after `inference server start` against `http://localhost:9001`.
- [ ] Confirm the serverless-variant script connects with a valid `requested_plan` / `requested_region`.