### PR TITLE
Fix factual gaps, dedup response schemas, make orphaned files discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,28 +49,23 @@ claude --plugin-dir .
 
 ### Codex
 
-Install from a local clone:
+This repo includes a repo-scoped Codex marketplace file at [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json), so a local clone can be registered directly.
 
 ```bash
 git clone https://github.com/roboflow/computer-vision-skills
 cd computer-vision-skills
-codex plugin install .
+codex plugin marketplace add .
 ```
 
-For a throwaway test without touching the installed-plugins list:
+Restart Codex after adding the marketplace, then open `/plugins` to browse the `roboflow` entry.
+
+For a remote marketplace source:
 
 ```bash
-codex --plugin-dir .
+codex plugin marketplace add roboflow/computer-vision-skills
 ```
 
-<details>
-<summary>Marketplace install (once published)</summary>
-
-```bash
-codex plugin install roboflow
-```
-
-</details>
+The current Codex CLI does not expose `codex plugin install` or `codex --plugin-dir`.
 
 Codex picks up `ROBOFLOW_API_KEY` from the same shell environment that launches the `codex` binary. Use a project-scoped `.env` if you need different keys per project.
 

--- a/README.md
+++ b/README.md
@@ -49,23 +49,28 @@ claude --plugin-dir .
 
 ### Codex
 
-This repo includes a repo-scoped Codex marketplace file at [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json), so a local clone can be registered directly.
+Install from a local clone:
 
 ```bash
 git clone https://github.com/roboflow/computer-vision-skills
 cd computer-vision-skills
-codex plugin marketplace add .
+codex plugin install .
 ```
 
-Restart Codex after adding the marketplace, then open `/plugins` to browse the `roboflow` entry.
-
-For a remote marketplace source:
+For a throwaway test without touching the installed-plugins list:
 
 ```bash
-codex plugin marketplace add roboflow/computer-vision-skills
+codex --plugin-dir .
 ```
 
-The current Codex CLI does not expose `codex plugin install` or `codex --plugin-dir`.
+<details>
+<summary>Marketplace install (once published)</summary>
+
+```bash
+codex plugin install roboflow
+```
+
+</details>
 
 Codex picks up `ROBOFLOW_API_KEY` from the same shell environment that launches the `codex` binary. Use a project-scoped `.env` if you need different keys per project.
 

--- a/skills/api-reference/SKILL.md
+++ b/skills/api-reference/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: roboflow-api-reference
-description: Use when looking up Roboflow REST or Inference API hosts, authentication patterns, SDK choice, or request/response formats; covers api.roboflow.com, serverless.roboflow.com, dedicated, and self-hosted localhost endpoints.
+description: Protocol-level facts for Roboflow REST and Inference APIs — URL patterns, auth, parameters, error codes, and SDK quick-start. For deployment strategy and Workflow execution patterns, see roboflow-inference.
 ---
 
-> **Tip:** If you're connected to the [Roboflow MCP server](https://github.com/roboflow/roboflow-mcp), prefer its tools (`projects_*`, `versions_*`, `models_*`, `workflows_*`, `images_*`, …) over raw REST calls — they handle auth, pagination, and typed responses for you. The REST patterns below stay relevant if you're not using MCP.
+> **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), prefer its tools (`projects_*`, `versions_*`, `models_*`, `workflows_*`, `images_*`, …) over raw REST calls — they handle auth, pagination, and typed responses for you. The REST patterns below stay relevant if you're not using MCP.
 
 # Roboflow API Reference — Overview
 
@@ -23,10 +23,10 @@ Use the `inference-sdk` Python package as the preferred client for all inference
 | Method | Where | Format |
 |--------|-------|--------|
 | Query parameter | All hosts | `?api_key=YOUR_KEY` |
-| Request body | Platform API | `"api_key": "YOUR_KEY"` in JSON body |
-| Header | Inference hosts | `Authorization: Bearer YOUR_KEY` (Python SDK handles this) |
+| Request body | Platform API + Workflow inference | `"api_key": "YOUR_KEY"` in JSON body |
+| Header | MCP server (`mcp.roboflow.com`) | `x-api-key: YOUR_KEY` (handled automatically by MCP) |
 
-API keys are workspace-scoped. Get yours from **Workspace Settings > API Keys** in the Roboflow dashboard.
+API keys are workspace-scoped. Get yours from **Workspace Settings > API Keys** in the Roboflow dashboard (`app.roboflow.com/{workspace}/settings/api`). Personal API keys are at `/settings/account` → API Keys tab.
 
 ## SDKs
 
@@ -69,7 +69,7 @@ result = model.predict("image.jpg", confidence=40).json()
 
 | Task | Host to Use |
 |------|-------------|
-| Run model inference (new projects) | `serverless.roboflow.com` |
+| Run model inference | `serverless.roboflow.com` |
 | Run Workflows | `serverless.roboflow.com` |
 | Upload images | `api.roboflow.com` |
 | Manage projects/versions | `api.roboflow.com` |

--- a/skills/api-reference/inference.md
+++ b/skills/api-reference/inference.md
@@ -1,10 +1,10 @@
 # Roboflow Inference API Reference
 
-> **Tip:** If you're connected to the [Roboflow MCP server](https://github.com/roboflow/roboflow-mcp), prefer `models_infer` (single-model) or `workflow_specs_run` / `workflows_run` (chained pipelines with annotated images) over raw HTTP calls — same operations, but auth is handled and responses are typed. The REST patterns below stay relevant if you're not using MCP.
+> **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), prefer `models_infer` (single-model) or `workflow_specs_run` / `workflows_run` (chained pipelines with annotated images) over raw HTTP calls — same operations, but auth is handled and responses are typed. The REST patterns below stay relevant if you're not using MCP.
 
-## Serverless v2 (Recommended)
+## Serverless Inference (Hosted API v2)
 
-Single endpoint for all model types and Workflows.
+Single endpoint for all model types and Workflows. V2 is credit-billed by execution time (seconds); the older v1 hosted API was billed per inference count — v2 is the current default for all new projects.
 
 ```
 POST https://serverless.roboflow.com/{dataset_id}/{version_id}
@@ -75,7 +75,10 @@ The recommended approach for visualization is **Workflows** — use `workflow_sp
       "x": 189.5, "y": 100,
       "width": 163, "height": 186,
       "class": "helmet",
-      "confidence": 0.544
+      "class_id": 0,
+      "confidence": 0.544,
+      "class_confidence": 0.544,
+      "detection_id": "uuid"
     }
   ],
   "image": { "width": 2048, "height": 1371 }
@@ -144,8 +147,8 @@ Same as object detection, plus a `keypoints` array per prediction:
       "width": 163, "height": 186,
       "class": "helmet", "confidence": 0.544,
       "keypoints": [
-        { "x": 189, "y": 20, "class_name": "top", "class_id": 0, "confidence": 0.91 },
-        { "x": 188, "y": 180, "class_name": "bottom", "class_id": 1, "confidence": 0.93 }
+        { "x": 189, "y": 20, "class": "top", "class_name": "top", "class_id": 0, "confidence": 0.91 },
+        { "x": 188, "y": 180, "class": "bottom", "class_name": "bottom", "class_id": 1, "confidence": 0.93 }
       ]
     }
   ],

--- a/skills/api-reference/rest-api.md
+++ b/skills/api-reference/rest-api.md
@@ -1,6 +1,6 @@
 # Roboflow Platform REST API Reference
 
-> **Tip:** If you're connected to the [Roboflow MCP server](https://github.com/roboflow/roboflow-mcp), prefer its tools (`projects_*`, `versions_*`, `images_*`, `annotations_save`, `models_train`, …) over raw REST calls — they handle auth and typed responses for you. The REST patterns below stay relevant if you're not using MCP.
+> **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), prefer its tools (`projects_*`, `versions_*`, `images_*`, `annotations_save`, `models_train`, …) over raw REST calls — they handle auth and typed responses for you. The REST patterns below stay relevant if you're not using MCP.
 
 Base URL: `https://api.roboflow.com`
 

--- a/skills/data-management/SKILL.md
+++ b/skills/data-management/SKILL.md
@@ -202,3 +202,7 @@ project.version(1).download("yolov8")
 | `versions_generate` | Generate a dataset version with preprocessing/augmentation |
 | `versions_get` | Inspect a version |
 | `versions_export` | Export a version in a given format |
+
+## Related Pages
+
+- `roboflow://skills/roboflow-labeling/SKILL` — annotation tools, AI labeling, Label Assist, Smart Polygon, Auto Label, annotation jobs

--- a/skills/data-management/labeling.md
+++ b/skills/data-management/labeling.md
@@ -1,3 +1,8 @@
+---
+name: roboflow-labeling
+description: Annotation tools, AI labeling features (Label Assist, Smart Polygon, Auto Label), annotation jobs, and labeling workflows in Roboflow.
+---
+
 # Labeling & Annotation on Roboflow
 
 ## Annotation Tools

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: roboflow-inference
-description: Use when running Roboflow model inference or choosing deployment (serverless, dedicated, self-hosted, batch); prefer Workflows over direct model calls.
+description: Deployment option comparison (serverless, dedicated, self-hosted, batch) and Workflow execution patterns. For raw API URL patterns, auth, and request/response formats, see roboflow-api-reference.
 ---
 
-> **Tip:** If you're connected to the [Roboflow MCP server](https://github.com/roboflow/roboflow-mcp), use its inference tools (`models_infer`, `workflow_specs_run`, `workflows_run`) directly — they cover the same operations as the HTTP endpoints below with auth handled. The HTTP patterns stay relevant if you're not using MCP.
+> **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), use its inference tools (`models_infer`, `workflow_specs_run`, `workflows_run`) directly — they cover the same operations as the HTTP endpoints below with auth handled. The HTTP patterns stay relevant if you're not using MCP.
 
 # Inference & Deployment
 
@@ -39,79 +39,7 @@ description: Use when running Roboflow model inference or choosing deployment (s
 
 ## Response Shapes by Task
 
-### Object Detection
-
-```json
-{
-  "predictions": [
-    {
-      "x": 320.5, "y": 240.0,
-      "width": 100, "height": 80,
-      "confidence": 0.92,
-      "class": "car",
-      "class_confidence": 0.92,
-      "class_id": 0,
-      "detection_id": "uuid"
-    }
-  ],
-  "image": { "width": 640, "height": 480 }
-}
-```
-
-`x`, `y` = center of bounding box. `width`, `height` = box dimensions.
-
-### Classification
-
-```json
-{
-  "predictions": [
-    { "class": "cat", "class_id": 0, "confidence": 0.95 },
-    { "class": "dog", "class_id": 1, "confidence": 0.05 }
-  ],
-  "top": "cat",
-  "confidence": 0.95
-}
-```
-
-### Instance Segmentation
-
-```json
-{
-  "predictions": [
-    {
-      "x": 320.5, "y": 240.0,
-      "width": 100, "height": 80,
-      "confidence": 0.88,
-      "class": "person",
-      "class_confidence": 0.88,
-      "class_id": 0,
-      "detection_id": "uuid",
-      "points": [
-        { "x": 280.0, "y": 200.0 },
-        { "x": 285.0, "y": 202.0 }
-      ]
-    }
-  ]
-}
-```
-
-### Keypoint Detection
-
-```json
-{
-  "predictions": [
-    {
-      "x": 320.5, "y": 240.0,
-      "width": 100, "height": 200,
-      "confidence": 0.91,
-      "class": "person",
-      "keypoints": [
-        { "x": 330.0, "y": 210.0, "confidence": 0.95, "class_id": 0, "class": "nose" }
-      ]
-    }
-  ]
-}
-```
+For canonical response shapes (object detection, classification, segmentation, keypoint) with all fields including `class_id`, `detection_id`, `class_confidence`, see `roboflow://skills/api-reference/inference`.
 
 ## Large Response Handling
 

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -1,6 +1,6 @@
 # Workflows
 
-> **Tip:** If you're connected to the [Roboflow MCP server](https://github.com/roboflow/roboflow-mcp), use `workflow_specs_run` (run a spec ad-hoc) or `workflows_run` (run a saved workflow) instead of raw HTTP — they return annotated images alongside JSON. The HTTP patterns stay relevant if you're not using MCP.
+> **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), use `workflow_specs_run` (run a spec ad-hoc) or `workflows_run` (run a saved workflow) instead of raw HTTP — they return annotated images alongside JSON. The HTTP patterns stay relevant if you're not using MCP.
 
 ## What Are Workflows
 

--- a/skills/product-navigation/SKILL.md
+++ b/skills/product-navigation/SKILL.md
@@ -118,3 +118,7 @@ When creating a project, choose one (cannot be changed later):
 | Keypoint Detection | Object pose/skeleton |
 | Single-Label Classification | One label per image |
 | Multi-Label Classification | Multiple labels per image |
+
+## Related Pages
+
+- `roboflow://skills/product-navigation/features-by-page` — intent-to-URL lookup table ("I want to do X → go here")

--- a/skills/product-navigation/features-by-page.md
+++ b/skills/product-navigation/features-by-page.md
@@ -108,9 +108,9 @@ Base URL: `https://app.roboflow.com`
 | Check credit usage | `/{ws}/settings/usage` | -- |
 | Purchase credits | `/{ws}/settings/plan` -> Buy Credits | -- |
 | Update payment method | `/{ws}/settings/plan` -> Payment tab | -- |
-
-For plans, credits, and cost estimation, see `roboflow://skills/plans-and-pricing/index`.
 | Get workspace API key | `/{ws}/settings/api` | -- |
 | Get personal API key | `/settings/account` -> API Keys | -- |
 | Configure SSO | `/{ws}/settings/plan` (Enterprise) | -- |
 | View audit logs | `/{ws}/settings/audit-logs` (Enterprise) | -- |
+
+For plans, credits, and cost estimation, see `roboflow://skills/plans-and-pricing/SKILL`.

--- a/skills/training-and-evaluation/SKILL.md
+++ b/skills/training-and-evaluation/SKILL.md
@@ -24,7 +24,7 @@ Upload/Annotate Images
 
 | Architecture | Sizes | Default Resolution | Notes |
 |---|---|---|---|
-| **RF-DETR** | Nano, Small, Medium, Large, XL, 2XL | 384-880 (varies by size) | Best accuracy, recommended default |
+| **RF-DETR** | Pico, Nano, Small, Base, Medium, Large, XL, 2XL | 384-880 (varies by size) | Best accuracy, recommended default |
 | Roboflow 3.0 | Fast, Accurate, Medium, Large, XL | 640x640 | YOLOv8-based. Medium+ require paid plan |
 | YOLO26 | n/s/m/l/x | 640x640 | Also supports seg + pose |
 | YOLOv12 | n/s/m/l/x | 640x640 | OD only |
@@ -39,7 +39,7 @@ Upload/Annotate Images
 
 | Architecture | Sizes | Default Resolution |
 |---|---|---|
-| **RF-DETR Seg** | Nano, Small, Medium, Large, XL, 2XL | 312-768 (varies) |
+| **RF-DETR Seg** | Nano, Small, Medium, Large, XL, 2XL | 312-768 (varies) | Pico and Base not available for seg |
 | Roboflow 3.0 Seg | Fast, Accurate, Medium, Large, XL | 640x640 |
 | YOLO-seg | v8/v11/v26 (n/s/m/l/x each) | 640x640 |
 | SAM 3 (Segment Anything 3) | Large | 1008x1008 |
@@ -85,14 +85,14 @@ Follow this flowchart to pick the right model. Start at Step 1.
 4. **Non-real-time, COCO** — Pick model family by task, default Medium size (Small for constrained HW, XL for accuracy-first): OD → RF-DETR, Inst Seg → RF-DETR Seg, Keypoint → YOLO26 pose. **Done.**
 5. **Real-time, COCO** — Same families, pick Nano–Small, prioritize latency. **Done.**
 6. **Non-COCO, which sub-task?** OD → Step 7. Inst Seg → Step 8. Keypoint → Step 9.
-7. **OD, non-COCO** — Check Rapid exclusions (see below). If excluded → recommend custom training (Step 17). Otherwise → recommend **Roboflow Rapid** (default) or SAM3 zero-shot as secondary option → Step 11.
-8. **Inst Seg, non-COCO** — SAM3 zero-shot (`sam3/sam3_final`, set `class_names`). Rapid does not support segmentation → Step 11.
+7. **OD, non-COCO** — Check Rapid exclusions (see below). If excluded → Step 13. Otherwise → recommend **Roboflow Rapid** (default) or SAM3 zero-shot as secondary option → Step 10.
+8. **Inst Seg, non-COCO** — SAM3 zero-shot (`sam3/sam3_final`, set `class_names`). Rapid does not support segmentation → Step 10.
 9. **Keypoint, non-COCO** — Not real-time → YOLO26 pose Medium–XL. Real-time → YOLO26 pose Nano–Small. **Done.**
-10. *(reserved)*
-11. **Real-time?** No → let user try model (Step 12). Yes → warn about latency, let user try (Step 13).
-12–13. User confirms works → **Done.** Poor results → Step 15.
-15. **Universe Model Search** — search community models on Roboflow Universe. Good match → **Done.** No match → Step 17.
-17. **Custom Training** — Fine-tune RF-DETR on user data. Size by HW constraints. **Done.**
+10. **Real-time?** No → try model (Step 11). Yes → warn about latency, try model (Step 12).
+11. **Non-real-time trial** — User confirms works → **Done.** Poor results → Step 13.
+12. **Real-time trial** — User confirms works → **Done.** Poor results → Step 13.
+13. **Universe Model Search** — search community models on Roboflow Universe. Good match → **Done.** No match → Step 14.
+14. **Custom Training** — Fine-tune RF-DETR on user data. Size by HW constraints. **Done.**
 
 ## Model ID Reference
 
@@ -258,3 +258,7 @@ Auto-runs after training. Access: Models > click model version > View Evaluation
 | Check training status | `models_get_training_status` |
 | Get model info | `models_get` |
 | List models | `models_list` |
+
+## Related Pages
+
+- `roboflow://skills/roboflow-model-improvement/SKILL` — diagnostic decision tree, confusion matrix guide, per-class metrics, architecture switching, iterative improvement checklist

--- a/skills/training-and-evaluation/improvement-playbook.md
+++ b/skills/training-and-evaluation/improvement-playbook.md
@@ -1,3 +1,8 @@
+---
+name: roboflow-model-improvement
+description: Diagnostic playbook for improving trained model accuracy — confusion matrix analysis, per-class metrics, common failure modes, architecture switching, and iterative improvement checklist.
+---
+
 # Model Improvement Playbook
 
 ## Diagnostic Decision Tree


### PR DESCRIPTION
- Replace broken github.com/roboflow/roboflow-mcp 404 link with mcp.roboflow.com in 5 files
- Fix Authorization: Bearer claim → x-api-key header for MCP, query param for inference hosts
- Add class_id, detection_id, class_confidence to OD schema in api-reference/inference.md; document both class and class_name in keypoint responses
- Remove duplicate response shape tables from inference/SKILL.md; cross-reference api-reference as canonical owner
- Add Pico + Base sizes to RF-DETR architecture table (6 → 8); renumber decision tree removing reserved step 10 and gaps at 14/16
- Add frontmatter to labeling.md and improvement-playbook.md so agents can load them as named skills; add Related Pages sections to data-management, training-and-evaluation, product-navigation SKILL.md files
- Sharpen api-reference and inference descriptions to eliminate routing overlap
- Fix broken URI plans-and-pricing/index → /SKILL in features-by-page.md; move cross-ref out of mid-table position
- Remove dangling "(new projects)" qualifier; clarify Serverless v2 vs v1 billing model