### PR TITLE
Add setup skill with API key wizard and CLAUDE.md gate rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # IDE files
 .idea/
+
+# Local Claude Code settings — may contain API keys
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# computer-vision-skills — Agent Instructions
+
+## Skill Editing Rule
+
+**All skill edits happen in this project, never in the plugin cache.**
+
+When asked to create, edit, or update any skill:
+
+- **Write to**: `skills/<skill-name>/SKILL.md` (relative to repo root)
+- **Never write to**: `~/.claude/plugins/cache/roboflow/**` or any path outside this repo
+
+The plugin cache is a read-only install artifact — changes there are overwritten on next `claude plugin install`. This repo is the canonical source.
+
+## Gate Rule — Secret Files Must Be Gitignored
+
+**Before any operation that creates `.claude/settings.local.json` in a project with git initialized:**
+
+1. Verify `.claude/settings.local.json` is present in `.gitignore` — if not, add it immediately before writing the file.
+2. Never commit `.claude/settings.local.json` under any circumstances.
+3. This rule is unconditional — no exceptions, no user override.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ The plugin cache is a read-only install artifact — changes there are overwritt
 
 ## Gate Rule — Secret Files Must Be Gitignored
 
-**Before any operation that creates `.claude/settings.local.json` in a project with git initialized:**
+**Before any operation that creates `.claude/settings.local.json` or `.codex/config.toml` in a project with git initialized:**
 
-1. Verify `.claude/settings.local.json` is present in `.gitignore` — if not, add it immediately before writing the file.
-2. Never commit `.claude/settings.local.json` under any circumstances.
+1. Verify the file path is present in `.gitignore` — if not, add it immediately before writing the file.
+2. Never commit `.claude/settings.local.json` or `.codex/config.toml` under any circumstances.
 3. This rule is unconditional — no exceptions, no user override.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -53,7 +53,9 @@ Use `AskUserQuestion` with these options:
 Question: "Where should the API key be configured?"
 Options:
   (a) Global — available in all projects on this machine (shell profile)
-  (b) Local — this project only (.claude/settings.local.json, gitignored)
+  (b) Local — Claude Code only (.claude/settings.local.json, gitignored)
+  (c) Local — Codex only (.codex/config.toml, gitignored)
+  (d) Local — both Claude Code and Codex
 ```
 
 ### Step 3 — Apply Configuration
@@ -74,20 +76,17 @@ source ~/.zshrc   # or source ~/.bashrc
 
 Instruct them to open a new Claude Code session after sourcing.
 
-**If user chose (b) Local:**
+**If user chose (b) Local — Claude Code or (d) both:**
 
 Before writing, handle gitignore based on project state:
 
 ```bash
-# 1. Is this a git repo?
 git rev-parse --is-inside-work-tree 2>/dev/null && IS_GIT=true || IS_GIT=false
 
 if [ "$IS_GIT" = "true" ]; then
   if [ -f .gitignore ]; then
-    # .gitignore exists — add entry if missing
     grep -qxF '.claude/settings.local.json' .gitignore || echo '.claude/settings.local.json' >> .gitignore
   else
-    # git repo but no .gitignore — create it
     echo '.claude/settings.local.json' > .gitignore
   fi
 fi
@@ -105,15 +104,48 @@ Write `.claude/settings.local.json` at the project root:
 
 Confirm the file was written and the gitignore entry is in place.
 
+**If user chose (c) Local — Codex or (d) both:**
+
+Before writing, handle gitignore based on project state:
+
+```bash
+git rev-parse --is-inside-work-tree 2>/dev/null && IS_GIT=true || IS_GIT=false
+
+if [ "$IS_GIT" = "true" ]; then
+  if [ -f .gitignore ]; then
+    grep -qxF '.codex/config.toml' .gitignore || echo '.codex/config.toml' >> .gitignore
+  else
+    echo '.codex/config.toml' > .gitignore
+  fi
+fi
+```
+
+Create the `.codex/` directory if it does not exist, then write `.codex/config.toml`:
+
+```toml
+[shell_environment_policy]
+set = { ROBOFLOW_API_KEY = "<key>" }
+
+[mcp_servers.roboflow.env]
+ROBOFLOW_API_KEY = "<key>"
+```
+
+`[shell_environment_policy]` makes the key available to all subprocesses Codex spawns.
+`[mcp_servers.roboflow.env]` scopes it directly to the Roboflow MCP server.
+
+Confirm the file was written and the gitignore entry is in place.
+
 ### Step 4 — Verify
 
-Run:
+**Claude Code path (options b or d):** Run:
 
 ```bash
 claude mcp list
 ```
 
 `roboflow` must appear with status connected. If not, see Troubleshooting.
+
+**Codex-only path (option c):** No automated verification available — confirm `.codex/config.toml` was written and instruct the user to launch Codex and run a Roboflow tool call to verify.
 
 Then ask Claude Code:
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -68,9 +68,14 @@ git rev-parse --is-inside-work-tree 2>/dev/null && IS_GIT=true || IS_GIT=false
 
 if [ "$IS_GIT" = "true" ]; then
   if [ -f .gitignore ]; then
-    grep -qxF '.claude/settings.local.json' .gitignore || echo '.claude/settings.local.json' >> .gitignore
+    if ! grep -qxF '.claude/settings.local.json' .gitignore; then
+      if [ -s .gitignore ] && [ "$(tail -c 1 .gitignore)" != "" ]; then
+        printf '\n' >> .gitignore
+      fi
+      printf '%s\n' '.claude/settings.local.json' >> .gitignore
+    fi
   else
-    echo '.claude/settings.local.json' > .gitignore
+    printf '%s\n' '.claude/settings.local.json' > .gitignore
   fi
 fi
 ```

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roboflow-setup
-description: Use when user asks how to configure the Roboflow MCP server, get or set their API key, wire the key into their environment globally or per project, or troubleshoot a missing key or unreachable MCP server.
+description: Use when user asks how to configure the Roboflow MCP server, get or set their API key, wire the key into their Claude Code or Codex environment, or troubleshoot a missing key or unreachable MCP server.
 ---
 
 # Roboflow MCP Configuration
@@ -52,31 +52,14 @@ Use `AskUserQuestion` with these options:
 ```
 Question: "Where should the API key be configured?"
 Options:
-  (a) Global — available in all projects on this machine (shell profile)
-  (b) Local — Claude Code only (.claude/settings.local.json, gitignored)
-  (c) Local — Codex only (.codex/config.toml, gitignored)
-  (d) Local — both Claude Code and Codex
+  (a) Local — Claude Code only (.claude/settings.local.json, gitignored)
+  (b) Local — Codex only (.codex/config.toml, gitignored)
+  (c) Local — both Claude Code and Codex
 ```
 
 ### Step 3 — Apply Configuration
 
-**If user chose (a) Global:**
-
-Show the user the exact line to add to their shell profile (`~/.zshrc` or `~/.bashrc`):
-
-```bash
-export ROBOFLOW_API_KEY="<key>"
-```
-
-Then show the reload command:
-
-```bash
-source ~/.zshrc   # or source ~/.bashrc
-```
-
-Instruct them to open a new Claude Code session after sourcing.
-
-**If user chose (b) Local — Claude Code or (d) both:**
+**If user chose (a) Local — Claude Code or (c) both:**
 
 Before writing, handle gitignore based on project state:
 
@@ -104,7 +87,7 @@ Write `.claude/settings.local.json` at the project root:
 
 Confirm the file was written and the gitignore entry is in place.
 
-**If user chose (c) Local — Codex or (d) both:**
+**If user chose (b) Local — Codex or (c) both:**
 
 Before writing, handle gitignore based on project state:
 
@@ -137,7 +120,7 @@ Confirm the file was written and the gitignore entry is in place.
 
 ### Step 4 — Verify
 
-**Claude Code path (options b or d):** Run:
+**Claude Code path (options a or c):** Run:
 
 ```bash
 claude mcp list
@@ -145,7 +128,7 @@ claude mcp list
 
 `roboflow` must appear with status connected. If not, see Troubleshooting.
 
-**Codex-only path (option c):** No automated verification available — confirm `.codex/config.toml` was written and instruct the user to launch Codex and run a Roboflow tool call to verify.
+**Codex-only path (option b):** No automated verification available — confirm `.codex/config.toml` was written and instruct the user to launch Codex and run a Roboflow tool call to verify.
 
 Then ask Claude Code:
 
@@ -157,7 +140,7 @@ Result list = auth working. Error = proceed to Troubleshooting.
 
 | Symptom | Likely Cause | Fix |
 |---------|-------------|-----|
-| `ROBOFLOW_API_KEY not set` | Env var not exported or stale session | `echo $ROBOFLOW_API_KEY`; source profile; open fresh Claude Code session |
+| `ROBOFLOW_API_KEY not set` | Key missing from `.claude/settings.local.json` or stale session | Check file exists and contains `env.ROBOFLOW_API_KEY`; open fresh Claude Code session |
 | `401 Unauthorized` | Wrong workspace key or key regenerated | Re-copy from `app.roboflow.com/{workspace}/settings/api`; update config |
 | `roboflow` not in `claude mcp list` | Plugin not installed | `claude plugin list`; if missing, see README install instructions |
 | MCP server unreachable | Network or firewall | `curl -I https://mcp.roboflow.com/mcp` |

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -80,14 +80,17 @@ if [ "$IS_GIT" = "true" ]; then
 fi
 ```
 
-Write `.claude/settings.local.json` at the project root:
+Create the `.claude` directory and write `.claude/settings.local.json` at the project root:
 
-```json
+```bash
+mkdir -p .claude
+cat > .claude/settings.local.json <<'EOF'
 {
   "env": {
     "ROBOFLOW_API_KEY": "<key>"
   }
 }
+EOF
 ```
 
 Confirm the file was written and the gitignore entry is in place.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: roboflow-setup
+description: Use when user asks how to configure the Roboflow MCP server, get or set their API key, wire the key into their environment globally or per project, or troubleshoot a missing key or unreachable MCP server.
+---
+
+# Roboflow MCP Configuration
+
+Run this as an interactive wizard. Follow the steps in order — each step gates the next.
+
+## Wizard Steps
+
+### Step 1 — Obtain the API Key
+
+First check whether the Roboflow CLI is available:
+
+```bash
+which roboflow
+```
+
+**If CLI is available** — instruct the user to log in (this stores the key in `~/.config/roboflow/config.json`):
+
+```bash
+roboflow auth login
+```
+
+After login, extract the key automatically:
+
+```bash
+python3 -c "
+import json, os
+cfg = json.load(open(os.path.expanduser('~/.config/roboflow/config.json')))
+print(list(cfg['workspaces'].values())[0]['apiKey'])
+"
+```
+
+Show the extracted key to the user and proceed to Step 2 with it.
+
+**If CLI is not available** — direct the user to the web UI:
+
+> Open `https://app.roboflow.com/{workspace}/settings/api`, copy the **Private API Key**, then come back.
+
+Then use `AskUserQuestion` to collect it:
+
+```
+Question: "Paste your Roboflow API key here (it will only be used to configure your environment — never stored in chat or committed to git):"
+```
+
+### Step 2 — Ask Scope
+
+Use `AskUserQuestion` with these options:
+
+```
+Question: "Where should the API key be configured?"
+Options:
+  (a) Global — available in all projects on this machine (shell profile)
+  (b) Local — this project only (.claude/settings.local.json, gitignored)
+```
+
+### Step 3 — Apply Configuration
+
+**If user chose (a) Global:**
+
+Show the user the exact line to add to their shell profile (`~/.zshrc` or `~/.bashrc`):
+
+```bash
+export ROBOFLOW_API_KEY="<key>"
+```
+
+Then show the reload command:
+
+```bash
+source ~/.zshrc   # or source ~/.bashrc
+```
+
+Instruct them to open a new Claude Code session after sourcing.
+
+**If user chose (b) Local:**
+
+Before writing, handle gitignore based on project state:
+
+```bash
+# 1. Is this a git repo?
+git rev-parse --is-inside-work-tree 2>/dev/null && IS_GIT=true || IS_GIT=false
+
+if [ "$IS_GIT" = "true" ]; then
+  if [ -f .gitignore ]; then
+    # .gitignore exists — add entry if missing
+    grep -qxF '.claude/settings.local.json' .gitignore || echo '.claude/settings.local.json' >> .gitignore
+  else
+    # git repo but no .gitignore — create it
+    echo '.claude/settings.local.json' > .gitignore
+  fi
+fi
+```
+
+Write `.claude/settings.local.json` at the project root:
+
+```json
+{
+  "env": {
+    "ROBOFLOW_API_KEY": "<key>"
+  }
+}
+```
+
+Confirm the file was written and the gitignore entry is in place.
+
+### Step 4 — Verify
+
+Run:
+
+```bash
+claude mcp list
+```
+
+`roboflow` must appear with status connected. If not, see Troubleshooting.
+
+Then ask Claude Code:
+
+> "Search Roboflow Universe for hard hat detection datasets."
+
+Result list = auth working. Error = proceed to Troubleshooting.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| `ROBOFLOW_API_KEY not set` | Env var not exported or stale session | `echo $ROBOFLOW_API_KEY`; source profile; open fresh Claude Code session |
+| `401 Unauthorized` | Wrong workspace key or key regenerated | Re-copy from `app.roboflow.com/{workspace}/settings/api`; update config |
+| `roboflow` not in `claude mcp list` | Plugin not installed | `claude plugin list`; if missing, see README install instructions |
+| MCP server unreachable | Network or firewall | `curl -I https://mcp.roboflow.com/mcp` |
+| Tools unavailable after key set | Session predates key | Open fresh terminal, relaunch Claude Code |
+
+## Related Skills
+
+- `roboflow://skills/api-reference/SKILL` — REST and Inference API auth patterns and SDK choice
+- `roboflow://skills/inference/SKILL` — running inference once setup is complete

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -23,17 +23,17 @@ which roboflow
 roboflow auth login
 ```
 
-After login, extract the key automatically:
+After login, extract the key into a variable:
 
 ```bash
-python3 -c "
+RF_KEY=$(python3 -c "
 import json, os
 cfg = json.load(open(os.path.expanduser('~/.config/roboflow/config.json')))
 print(list(cfg['workspaces'].values())[0]['apiKey'])
-"
+")
 ```
 
-Show the extracted key to the user and proceed to Step 2 with it.
+Confirm the key was extracted (reply "API key found — proceeding to Step 2") without displaying its value. Proceed to Step 2; use `$RF_KEY` wherever the key is needed in Step 3.
 
 **If CLI is not available** — direct the user to the web UI:
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -84,10 +84,10 @@ Create the `.claude` directory and write `.claude/settings.local.json` at the pr
 
 ```bash
 mkdir -p .claude
-cat > .claude/settings.local.json <<'EOF'
+cat > .claude/settings.local.json <<EOF
 {
   "env": {
-    "ROBOFLOW_API_KEY": "<key>"
+    "ROBOFLOW_API_KEY": "$RF_KEY"
   }
 }
 EOF
@@ -113,12 +113,15 @@ fi
 
 Create the `.codex/` directory if it does not exist, then write `.codex/config.toml`:
 
-```toml
+```bash
+mkdir -p .codex
+cat > .codex/config.toml <<EOF
 [shell_environment_policy]
-set = { ROBOFLOW_API_KEY = "<key>" }
+set = { ROBOFLOW_API_KEY = "$RF_KEY" }
 
 [mcp_servers.roboflow.env]
-ROBOFLOW_API_KEY = "<key>"
+ROBOFLOW_API_KEY = "$RF_KEY"
+EOF
 ```
 
 `[shell_environment_policy]` makes the key available to all subprocesses Codex spawns.


### PR DESCRIPTION
- New skills/setup/SKILL.md — interactive wizard: detect Roboflow CLI, collect API key via AskUserQuestion, ask global vs local scope, handle gitignore (create if missing), write shell profile or settings.local.json
- New CLAUDE.md — gate rules: edit skills in project not plugin cache, always gitignore .claude/settings.local.json before writing it
- .gitignore — add .claude/settings.local.json entry
