### PR TITLE
Migrate remaining `/index` URIs to `/SKILL` in `universe/SKILL.md`

### DIFF
--- a/skills/universe/SKILL.md
+++ b/skills/universe/SKILL.md
@@ -147,5 +147,5 @@ Returns: name, url, type, classes, classCount, images, description, tags, licens
 
 ## Related Skills
 
-- `roboflow://skills/data-management/index` — managing datasets after import
-- `roboflow://skills/training-and-evaluation/index` — training on forked data
+- `roboflow://skills/data-management/SKILL` — managing datasets after import
+- `roboflow://skills/training-and-evaluation/SKILL` — training on forked data


### PR DESCRIPTION
## Summary

`skills/universe/SKILL.md` still uses the legacy `/index` suffix on `roboflow://` resource URIs. PR #7 migrated this exact pattern (`/index` → `/SKILL`) in `skills/product-navigation/features-by-page.md` after the `index.md` → `SKILL.md` rename in 7db9842, but missed two siblings in `universe/SKILL.md`. This applies the same fix.

### Before

```markdown
## Related Skills

- `roboflow://skills/data-management/index` — managing datasets after import
- `roboflow://skills/training-and-evaluation/index` — training on forked data
```

### After

```markdown
## Related Skills

- `roboflow://skills/data-management/SKILL` — managing datasets after import
- `roboflow://skills/training-and-evaluation/SKILL` — training on forked data
```

## Repro

```bash
grep -rn '/index' skills/ --include='*.md'
# skills/universe/SKILL.md:150:- `roboflow://skills/data-management/index` — managing datasets after import
# skills/universe/SKILL.md:151:- `roboflow://skills/training-and-evaluation/index` — training on forked data
```

After this PR: no matches.

## Test plan

- [x] `grep -rn '/index' skills/ --include='*.md'` returns no matches.
- [x] Pattern matches the canonical form used in `features-by-page.md:116` (`roboflow://skills/plans-and-pricing/SKILL`).
- [x] Both referenced targets exist: `skills/data-management/SKILL.md` and `skills/training-and-evaluation/SKILL.md`.