### PR TITLE
Fix broken refs in `inference/local-tooling.md`

### DIFF
--- a/skills/inference/local-tooling.md
+++ b/skills/inference/local-tooling.md
@@ -1,6 +1,6 @@
 # Local Tooling — When MCP Isn't Enough
 
-> **Tip:** Prefer the [Roboflow MCP server](https://github.com/roboflow/roboflow-mcp) for anything it covers — it handles auth and needs nothing installed locally. This page is for the gaps where you need local Python tooling.
+> **Tip:** Prefer the [Roboflow MCP server](https://mcp.roboflow.com) for anything it covers — it handles auth and needs nothing installed locally. This page is for the gaps where you need local Python tooling.
 
 ## When you need local tooling
 
@@ -9,9 +9,9 @@ Reach for local Python packages only when an operation has no MCP equivalent.
 | Need | Install | Surface |
 |---|---|---|
 | Inference inside your **own application** (server, script, notebook) | `inference-sdk` | `InferenceHTTPClient` |
-| **Batch Processing** / **Data Staging** (see [`batch-staging`](batch-staging.md), [`batch-jobs`](batch-jobs.md)) | `inference-cli` | `inference rf-cloud …` |
+| **Batch Processing** / **Data Staging** | `inference-cli` | `inference rf-cloud …` |
 | **Self-hosted inference server** (Docker, on-prem, edge) | `inference-cli` | `inference server start` |
-| Asset scripts that need typed Python objects (e.g. [`assets/poll_batch_job.py`](assets/poll_batch_job.py)) | `inference-cli` | `from inference_cli.lib.roboflow_cloud…` |
+| Asset scripts that need typed Python objects | `inference-cli` | `from inference_cli.lib.roboflow_cloud…` |
 
 ## Confirm the target env with the user first
 


### PR DESCRIPTION
## Summary

`skills/inference/local-tooling.md`, added in #10, ships three broken references:

1. **Line 3** links to `https://github.com/roboflow/roboflow-mcp` — this URL 404s. PR #7 explicitly removed this link from 5 other files ("Replace broken github.com/roboflow/roboflow-mcp 404 link with mcp.roboflow.com in 5 files"); #10 reintroduced it in this new file.
2. **Line 12** links to `batch-staging.md` and `batch-jobs.md` — neither file exists in `skills/inference/`. They live on the unmerged `feature/batch-processing-skill-evolution` branch.
3. **Line 14** links to `assets/poll_batch_job.py` — also lives only on the unmerged feature branch.

This PR restores #7's MCP link replacement and removes the parenthetical clauses pointing at files not present on `main`. The surrounding prose still describes each use case; the cross-references can be re-added in the PR that merges the rest of the feature branch.

## Repro

```bash
# 1. Confirm the GitHub URL is dead
curl -s -o /dev/null -w "%{http_code}\n" -L https://github.com/roboflow/roboflow-mcp
# → 404

# 2. Confirm the replacement works
curl -s -o /dev/null -w "%{http_code}\n" https://mcp.roboflow.com
# → 200

# 3. Confirm the three intra-doc files don't exist on main
ls skills/inference/
# → CLAUDE.md  SKILL.md  local-tooling.md  workflow-templates.md  workflows.md
# (no batch-staging.md, no batch-jobs.md, no assets/)
```

## Test plan

- [x] After the fix: `grep -rn 'github.com/roboflow/roboflow-mcp\|batch-staging\|batch-jobs\|poll_batch_job' skills/ --include='*.md'` returns no matches.
- [x] Repo-wide `grep -rn 'github.com/roboflow/roboflow-mcp' . --include='*.md' --include='*.json'` returns no matches — this was the last surviving instance.
- [x] `https://mcp.roboflow.com` returns HTTP 200.
- [x] Surrounding prose in the table still describes each use case without the broken links.