### PR TITLE
feat(agent-install): publish installer scripts to repo.roboflow.com/agent-install

### DIFF
--- a/.github/workflows/publish-agent-install.yml
+++ b/.github/workflows/publish-agent-install.yml
@@ -1,0 +1,66 @@
+name: Publish agent-install
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "agent-install/**"
+      - ".github/workflows/publish-agent-install.yml"
+  workflow_dispatch: {}
+
+# Least-privilege at the workflow level. id-token is required for WIF;
+# contents: read is enough for actions/checkout.
+permissions:
+  contents: read
+  id-token: write
+
+# One publish at a time, never cancel an in-flight upload.
+concurrency:
+  group: publish-agent-install
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Requiring an environment lets us add manual approval / restrict to main
+    # via the repo's environment protection rules without touching this file.
+    environment: agent-install-prod
+    env:
+      BUCKET_NAME: roboflow-platform-agent-install
+      PROJECT: roboflow-platform
+      OIDC_PROJECT_ID: "481589474394"
+      SERVICE_ACCOUNT: gha-computer-vision-skills
+      WIF_POOL_ID: github-actions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/${{ env.OIDC_PROJECT_ID }}/locations/global/workloadIdentityPools/${{ env.WIF_POOL_ID }}/providers/github
+          service_account: ${{ env.SERVICE_ACCOUNT }}@${{ env.PROJECT }}.iam.gserviceaccount.com
+
+      - name: Upload agent.sh
+        uses: google-github-actions/upload-cloud-storage@v3
+        with:
+          parent: false
+          path: agent-install/agent.sh
+          destination: ${{ env.BUCKET_NAME }}/
+          process_gcloudignore: false
+          headers: |-
+            content-type: text/x-shellscript; charset=utf-8
+            cache-control: no-cache, max-age=0
+
+      - name: Upload agent.ps1
+        uses: google-github-actions/upload-cloud-storage@v3
+        with:
+          parent: false
+          path: agent-install/agent.ps1
+          destination: ${{ env.BUCKET_NAME }}/
+          process_gcloudignore: false
+          headers: |-
+            content-type: text/plain; charset=utf-8
+            cache-control: no-cache, max-age=0

--- a/agent-install/agent.ps1
+++ b/agent-install/agent.ps1
@@ -1,0 +1,12 @@
+# Roboflow agent installer (Windows / PowerShell).
+#
+# Served from https://repo.roboflow.com/agent-install/agent.ps1
+# Source of truth: https://github.com/roboflow/computer-vision-skills/blob/main/agent-install/agent.ps1
+#
+# Usage:
+#   iwr -useb https://repo.roboflow.com/agent-install/agent.ps1 | iex
+#
+# TODO: install logic.
+$ErrorActionPreference = "Stop"
+
+Write-Host "Roboflow agent installer - placeholder. Replace with real install logic."

--- a/agent-install/agent.sh
+++ b/agent-install/agent.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Roboflow agent installer (macOS / Linux).
+#
+# Served from https://repo.roboflow.com/agent-install/agent.sh
+# Source of truth: https://github.com/roboflow/computer-vision-skills/blob/main/agent-install/agent.sh
+#
+# Usage:
+#   curl -fsSL https://repo.roboflow.com/agent-install/agent.sh | bash
+#
+# TODO: install logic.
+set -euo pipefail
+
+echo "Roboflow agent installer — placeholder. Replace with real install logic."


### PR DESCRIPTION
## Summary

Adds `agent-install/` containing two installer scripts and a GitHub Actions workflow that publishes them to `https://repo.roboflow.com/agent-install/`:

- `agent.sh` → `curl -fsSL https://repo.roboflow.com/agent-install/agent.sh | bash`
- `agent.ps1` → `iwr -useb https://repo.roboflow.com/agent-install/agent.ps1 | iex`

The shipped scripts are **placeholders** — they `echo` a "replace me" message. Real install logic will follow in a subsequent PR.

## Security model

This is a public repo, so the publish path is locked down narrowly:

- The workflow runs only on push to `main` with `agent-install/**` paths, plus manual `workflow_dispatch`. No `pull_request` trigger — forks and PRs cannot run it.
- It authenticates to GCP via Workload Identity Federation. The WIF binding is scoped to `attribute.repository/roboflow/computer-vision-skills`, so no other repo (and no fork) can impersonate the service account.
- A `concurrency` group prevents overlapping uploads.
- An `environment: agent-install-prod` reference makes it trivial to add manual approval / branch restrictions later via repo settings, no code change needed.

## Test plan

- [ ] Merge → confirm the `Publish agent-install` workflow runs on the merge commit.
- [ ] `curl -fsSL https://repo.roboflow.com/agent-install/agent.sh` returns the placeholder script.
- [ ] `curl -fsSL https://repo.roboflow.com/agent-install/agent.ps1` returns the placeholder script.
- [ ] `curl -I` shows `Cache-Control: no-cache, max-age=0` so installer rollouts are immediate.