### PR TITLE
Update MCP image upload tool names in skills docs

### DIFF
--- a/skills/data-management/SKILL.md
+++ b/skills/data-management/SKILL.md
@@ -200,7 +200,7 @@ project.version(1).download("yolov8")
 | `projects_create` | Create a new project (specify type, annotation group) |
 | `projects_list` / `projects_get` | List or get project details |
 | `images_search` | Search images using RoboQL filters |
-| `images_prepare_upload` | Prepare image upload to a project |
+| `image_upload` / `image_upload_status` | Prepare zip image upload and poll status |
 | `versions_generate` | Generate a dataset version with preprocessing/augmentation |
 | `versions_get` | Inspect a version |
 | `versions_export` | Export a version in a given format |

--- a/skills/product-navigation/features-by-page.md
+++ b/skills/product-navigation/features-by-page.md
@@ -10,7 +10,7 @@ Base URL: `https://app.roboflow.com`
 
 | Intent | Web URL | Alternatives |
 |--------|---------|-------------|
-| Upload images/videos | `/{ws}/{proj}/upload` | Python SDK: `project.upload(path)`, MCP: `images_prepare_upload` |
+| Upload images/videos | `/{ws}/{proj}/upload` | Python SDK: `project.upload(path)`, MCP: `image_upload` + `image_upload_status` |
 | Import from S3/GCS/Azure | `/{ws}/{proj}/upload` -> Cloud Import tab | Python SDK with cloud URLs |
 | Import from Universe | `/{ws}/{proj}/upload` -> Universe tab | MCP: `universe_search` then fork |
 | Upload pre-annotated data | `/{ws}/{proj}/upload` (drag folder with annotations) | Python SDK: `project.upload(path)` auto-detects annotations |


### PR DESCRIPTION
# Description

Rename MCP upload tool references to `image_upload` and `image_upload_status` (pairs with roboflow/roboflow-mcp#63).

## Type of change

- [x] Documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

Doc-only; grep for removed tool names.

## Will the change affect Universe? If so was this change tested in universe?

No.

## Any specific deployment considerations

None.

Made with [Cursor](https://cursor.com)