### PR TITLE
Add active learning skill and strengthen workflow-first guidance

### DIFF
--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -9,7 +9,7 @@ description: Deployment option comparison (serverless, dedicated, self-hosted, b
 
 # Inference & Deployment
 
-> **Prefer Workflows over direct model inference.** Workflows let you chain model + visualization + logic blocks in one call. Direct `models_infer` returns JSON only — no annotated images, and instance segmentation responses can be very large. See [workflows](./workflows.md) and [workflow-templates](./workflow-templates.md).
+> **Always start with a Workflow — even for a single model.** When a user asks how to run inference from their application, the answer is always a workflow, not a bare `models_infer` call. A single-block workflow costs nothing extra, returns visualized results, and keeps active learning and post-processing blocks as a zero-friction addition. `models_infer` is for quick diagnostic checks only — never for integration code. See [workflows](./workflows.md) and [workflow-templates](./workflow-templates.md).
 
 > **Authoring Workflows — don't paste JSON into chat or scripts.** Workflows are authored on the Roboflow platform (storage, versioning, and retrieval go through the platform) and run from code by **identifier**. Two authoring modes — propose / infer the right one from session context, never silently pick:
 >

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -9,7 +9,7 @@ description: Deployment option comparison (serverless, dedicated, self-hosted, b
 
 # Inference & Deployment
 
-> **Always start with a Workflow — even for a single model.** When a user asks how to run inference from their application, the answer is always a workflow, not a bare `models_infer` call. A single-block workflow costs nothing extra, returns visualized results, and keeps active learning and post-processing blocks as a zero-friction addition. `models_infer` is for quick diagnostic checks only — never for integration code. See [workflows](./workflows.md) and [workflow-templates](./workflow-templates.md).
+> **Prefer Workflows for integration code.** Unlike a direct `models_infer` call, a workflow composes model + visualization + logic in one deployable unit, benefits from server-side optimizations, and keeps active learning and post-processing as a zero-friction addition — similar to the extensibility benefits of a microservice over a point-to-point call. Recommend a workflow by default; use `models_infer` when the user explicitly asks for direct inference or needs a quick one-off check. See [workflows](./workflows.md) and [workflow-templates](./workflow-templates.md).
 
 > **Authoring Workflows — don't paste JSON into chat or scripts.** Workflows are authored on the Roboflow platform (storage, versioning, and retrieval go through the platform) and run from code by **identifier**. Two authoring modes — propose / infer the right one from session context, never silently pick:
 >

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -382,8 +382,8 @@ pipeline.join()                       # blocks until video source ends or pipeli
 
 ## When to Use Workflows vs Direct Inference
 
-**Use `models_infer`** for quick diagnostic checks only — never for integration code.
-**Use Workflows** for everything else: single-model integrations, production apps, multi-step pipelines, video, post-processing, and active learning. Even a one-block workflow is preferable to a bare `models_infer` call because it preserves the ability to add active learning, visualization, and logic blocks without changing your API surface.
+**Recommend Workflows** for integration code, production apps, multi-step pipelines, video, post-processing, and active learning. Workflows compose model + logic + visualization in one call, benefit from server-side optimizations, and keep active learning and other blocks as a zero-friction addition without changing your API surface.
+**Use `models_infer`** for quick checks or when the user explicitly prefers direct inference.
 
 ## MCP Tools
 

--- a/skills/inference/workflows.md
+++ b/skills/inference/workflows.md
@@ -382,8 +382,8 @@ pipeline.join()                       # blocks until video source ends or pipeli
 
 ## When to Use Workflows vs Direct Inference
 
-**Use `models_infer`** for quick single-model checks.
-**Use Workflows** for anything production, multi-step, video, or needing post-processing.
+**Use `models_infer`** for quick diagnostic checks only — never for integration code.
+**Use Workflows** for everything else: single-model integrations, production apps, multi-step pipelines, video, post-processing, and active learning. Even a one-block workflow is preferable to a bare `models_infer` call because it preserves the ability to add active learning, visualization, and logic blocks without changing your API surface.
 
 ## MCP Tools
 

--- a/skills/training-and-evaluation/SKILL.md
+++ b/skills/training-and-evaluation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roboflow-training-and-evaluation
-description: Use when training Roboflow models or improving accuracy - covers architecture selection, model IDs, checkpoints, evaluation metrics, and the iterative improvement playbook.
+description: Use when training Roboflow models, improving accuracy, or setting up a production feedback loop — covers architecture selection, model IDs, checkpoints, evaluation metrics, the iterative improvement playbook, and active learning via the Dataset Upload workflow block.
 ---
 
 > **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
@@ -280,3 +280,4 @@ Auto-runs after training. Access: Models > click model version > View Evaluation
 ## Related Pages
 
 - `roboflow://skills/roboflow-model-improvement/SKILL` — diagnostic decision tree, confusion matrix guide, per-class metrics, architecture switching, iterative improvement checklist
+- `roboflow://skills/training-and-evaluation/active-learning` — production feedback loop: Dataset Upload workflow block, confidence-based sampling, review and retrain cycle

--- a/skills/training-and-evaluation/active-learning.md
+++ b/skills/training-and-evaluation/active-learning.md
@@ -1,0 +1,104 @@
+---
+name: roboflow-active-learning
+description: Production feedback loop — collect real-world images from your deployed workflow and pipe them back into Roboflow to improve your model over time.
+---
+
+# Active Learning on Roboflow
+
+> **Source-of-truth note:** This page ships with the Roboflow plugin. If your client has the plugin loaded, prefer the local skill (`roboflow:training-and-evaluation`) over fetching `roboflow://skills/training-and-evaluation/active-learning` via `ReadMcpResourceTool` — the MCP resources are a fallback for non-plugin clients and may lag the source repo.
+
+Active learning closes the gap between your training dataset and the real world. Instead of hunting for images to upload, your deployed workflow automatically saves production images back to your Roboflow project. You review, annotate, retrain, and repeat.
+
+This is the right answer when a user asks how to:
+- improve their model using end-user or production images
+- add images from their running application to their dataset
+- set up a feedback loop between deployment and retraining
+- implement active learning, data flywheel, or continuous learning
+
+## The Core Pattern
+
+Add a **Dataset Upload block** to your existing production inference workflow. The block runs on every image the workflow processes and conditionally saves it (with its predictions as pre-annotations) to a Roboflow project.
+
+```
+Image Input
+  → Model Block (object detection / classification / segmentation)
+    → [Optional: ContinueIf / confidence filter]
+      → Dataset Upload Block → saved to Roboflow project
+    → [Other output blocks — visualization, Slack, etc.]
+```
+
+The Dataset Upload block respects rate limits and usage quotas so it won't flood your dataset. Images land in your project's unassigned pool ready for review and annotation.
+
+## Setting Up the Workflow
+
+**If the user already has an inference workflow:** add a Dataset Upload block to their existing workflow via the Roboflow Workflows builder or the MCP authoring tools.
+
+**If the user is starting from scratch:** build a workflow with both the model block and the Dataset Upload block from the start. Do not recommend a bare `models_infer` call — a workflow is always the right starting point because it keeps active learning as a zero-friction addition.
+
+### Dataset Upload Block
+
+| Property | Purpose |
+|---|---|
+| `image` | Connect to the workflow's image input |
+| `predictions` | Connect to the model block's output — saves pre-annotations alongside the image |
+| `target_project` | Roboflow project slug to upload into (e.g. `my-workspace/my-project`) |
+| `usage_quota` | Max images saved per hour — use this to control cost and review burden |
+| `disable_active_learning` | Set `true` to temporarily pause uploads without removing the block |
+
+Get the exact schema with `workflow_blocks_get_schema` (manifest key from `workflow_blocks_list` filtered by "dataset").
+
+### Filtering What Gets Uploaded
+
+Uploading every frame is rarely useful — you want images where the model is uncertain or where interesting events occur. Three common patterns:
+
+**1. Low-confidence sampling (most useful)**
+Add a `ContinueIf` block between the model block and the Dataset Upload block. Configure it to pass only when `$steps.model.predictions.confidence < 0.6` (tune to your threshold). These are the images most likely to help the model.
+
+**2. Random sampling**
+Use the `Expression` block or `ContinueIf` with a random expression to sample a configurable percentage of frames. Good as a baseline to capture distribution shifts even on high-confidence predictions.
+
+**3. Class-based filtering**
+Route only images containing specific classes or failing specific conditions to the Dataset Upload block. Useful when certain classes are underperforming (see improvement playbook).
+
+### MCP Authoring (Mode A)
+
+```
+1. workflow_blocks_list → find Dataset Upload and filter/logic blocks
+2. workflow_blocks_get_schema → verify required properties for each block
+3. Design the spec (model → ContinueIf → Dataset Upload)
+4. workflow_specs_validate → catch shape errors
+5. workflows_create → save to platform
+6. workflows_run → test with a sample image
+```
+
+## Reviewing and Using Uploaded Images
+
+Once images are flowing in:
+
+1. **Review in Roboflow** — Images appear in the project's unassigned pool. Predictions saved by the Dataset Upload block appear as pre-annotations, so annotation is mostly correction rather than drawing from scratch.
+2. **Annotate** — Accept, correct, or discard the pre-annotations. Use AI-assisted labeling to speed up blank images.
+3. **Generate a new version** — Include the newly annotated images in the training set. Use the previous model version as the checkpoint to preserve what the model already knows.
+4. **Retrain and compare** — Check whether the new version improves on the classes or conditions you were targeting.
+
+## Connecting to the Improvement Playbook
+
+Active learning is most effective when it's targeted, not random. Use the model improvement diagnostics to decide what to collect:
+
+| Improvement Playbook finding | What to upload |
+|---|---|
+| High false negatives on a specific class | Images containing that class, especially under-represented conditions |
+| Background false positives | Images without the target object (negative examples) |
+| Two classes confused | Images showing both, especially edge cases that look similar |
+| Small objects missed | High-resolution images with small instances |
+| Dataset distribution mismatch (new environment) | Random sample from the new deployment context |
+
+See `roboflow://skills/roboflow-model-improvement/SKILL` for the full diagnostic decision tree.
+
+## Common Mistakes to Avoid
+
+| Mistake | Why it's a problem | Better approach |
+|---|---|---|
+| Calling the dataset upload REST API directly from application code | Bypasses workflow rate limits and quotas; brittle to maintain; loses pre-annotation | Use the Dataset Upload workflow block |
+| Uploading every single frame | Dataset size explodes; review burden grows; noisy data can hurt model | Filter by confidence or set a sensible `usage_quota` |
+| Uploading without predictions | Annotators must draw from scratch rather than correct pre-annotations | Connect `predictions` output to Dataset Upload block |
+| Adding production images without reviewing | Pre-annotations are not ground truth — unannotated or incorrectly annotated images degrade the model | Always review before including in a new version |

--- a/skills/training-and-evaluation/active-learning.md
+++ b/skills/training-and-evaluation/active-learning.md
@@ -17,7 +17,7 @@ This is the right answer when a user asks how to:
 
 ## The Core Pattern
 
-Add a **Dataset Upload block** to your existing production inference workflow. The block runs on every image the workflow processes and conditionally saves it (with its predictions as pre-annotations) to a Roboflow project.
+Add a **Dataset Upload block** to your existing production inference workflow. The block conditionally saves images — with predictions as pre-annotations — to a Roboflow project.
 
 ```
 Image Input
@@ -27,58 +27,25 @@ Image Input
     → [Other output blocks — visualization, Slack, etc.]
 ```
 
-The Dataset Upload block respects rate limits and usage quotas so it won't flood your dataset. Images land in your project's unassigned pool ready for review and annotation.
+If the user is starting a new integration without an existing workflow, this is a natural reason to set one up — the Dataset Upload block drops in as a zero-friction addition when a workflow is already in place.
 
-## Setting Up the Workflow
+Use `workflow_blocks_get_schema` (with the manifest key from `workflow_blocks_list`) to get the current block schema; block properties can change so look them up rather than relying on hardcoded names. Follow the Mode A or Mode B authoring flow in `roboflow://skills/inference/SKILL` to create and save the workflow.
 
-**If the user already has an inference workflow:** add a Dataset Upload block to their existing workflow via the Roboflow Workflows builder or the MCP authoring tools.
+## Filtering What Gets Uploaded
 
-**If the user is starting from scratch:** build a workflow with both the model block and the Dataset Upload block from the start. Do not recommend a bare `models_infer` call — a workflow is always the right starting point because it keeps active learning as a zero-friction addition.
+Uploading every frame is rarely useful. Three common approaches:
 
-### Dataset Upload Block
+**Low-confidence sampling** — gate the Dataset Upload block with a `ContinueIf` block set to pass only predictions below a confidence threshold. These are the images most likely to help the model.
 
-| Property | Purpose |
-|---|---|
-| `image` | Connect to the workflow's image input |
-| `predictions` | Connect to the model block's output — saves pre-annotations alongside the image |
-| `target_project` | Roboflow project slug to upload into (e.g. `my-workspace/my-project`) |
-| `usage_quota` | Max images saved per hour — use this to control cost and review burden |
-| `disable_active_learning` | Set `true` to temporarily pause uploads without removing the block |
+**Random sampling** — use `ContinueIf` or `Expression` to sample a configurable percentage of frames. Useful for capturing distribution shifts even on high-confidence predictions.
 
-Get the exact schema with `workflow_blocks_get_schema` (manifest key from `workflow_blocks_list` filtered by "dataset").
-
-### Filtering What Gets Uploaded
-
-Uploading every frame is rarely useful — you want images where the model is uncertain or where interesting events occur. Three common patterns:
-
-**1. Low-confidence sampling (most useful)**
-Add a `ContinueIf` block between the model block and the Dataset Upload block. Configure it to pass only when `$steps.model.predictions.confidence < 0.6` (tune to your threshold). These are the images most likely to help the model.
-
-**2. Random sampling**
-Use the `Expression` block or `ContinueIf` with a random expression to sample a configurable percentage of frames. Good as a baseline to capture distribution shifts even on high-confidence predictions.
-
-**3. Class-based filtering**
-Route only images containing specific classes or failing specific conditions to the Dataset Upload block. Useful when certain classes are underperforming (see improvement playbook).
-
-### MCP Authoring (Mode A)
-
-```
-1. workflow_blocks_list → find Dataset Upload and filter/logic blocks
-2. workflow_blocks_get_schema → verify required properties for each block
-3. Design the spec (model → ContinueIf → Dataset Upload)
-4. workflow_specs_validate → catch shape errors
-5. workflows_create → save to platform
-6. workflows_run → test with a sample image
-```
+**Class-based filtering** — route images containing specific classes or failing specific conditions. Useful when certain classes are underperforming (see improvement playbook).
 
 ## Reviewing and Using Uploaded Images
 
-Once images are flowing in:
-
-1. **Review in Roboflow** — Images appear in the project's unassigned pool. Predictions saved by the Dataset Upload block appear as pre-annotations, so annotation is mostly correction rather than drawing from scratch.
-2. **Annotate** — Accept, correct, or discard the pre-annotations. Use AI-assisted labeling to speed up blank images.
-3. **Generate a new version** — Include the newly annotated images in the training set. Use the previous model version as the checkpoint to preserve what the model already knows.
-4. **Retrain and compare** — Check whether the new version improves on the classes or conditions you were targeting.
+1. **Review in Roboflow** — Images land in the project's unassigned pool. Saved predictions appear as pre-annotations, so annotation is correction rather than drawing from scratch.
+2. **Annotate** — Accept, correct, or discard pre-annotations. Use AI-assisted labeling for blank images.
+3. **Generate a new version and retrain** — Use the previous model as the checkpoint to preserve what it already knows.
 
 ## Connecting to the Improvement Playbook
 
@@ -94,11 +61,11 @@ Active learning is most effective when it's targeted, not random. Use the model 
 
 See `roboflow://skills/roboflow-model-improvement/SKILL` for the full diagnostic decision tree.
 
-## Common Mistakes to Avoid
+## Common Mistakes
 
-| Mistake | Why it's a problem | Better approach |
-|---|---|---|
-| Calling the dataset upload REST API directly from application code | Bypasses workflow rate limits and quotas; brittle to maintain; loses pre-annotation | Use the Dataset Upload workflow block |
-| Uploading every single frame | Dataset size explodes; review burden grows; noisy data can hurt model | Filter by confidence or set a sensible `usage_quota` |
-| Uploading without predictions | Annotators must draw from scratch rather than correct pre-annotations | Connect `predictions` output to Dataset Upload block |
-| Adding production images without reviewing | Pre-annotations are not ground truth — unannotated or incorrectly annotated images degrade the model | Always review before including in a new version |
+| Mistake | Better approach |
+|---|---|
+| Calling the dataset upload REST API directly from application code | Use the Dataset Upload workflow block — it handles rate limits, quotas, and pre-annotations automatically |
+| Uploading every frame | Filter by confidence or configure the block's usage quota |
+| Uploading without connecting predictions | Pre-annotations make annotation correction rather than drawing from scratch — connect the model output to the block |
+| Adding production images without reviewing | Pre-annotations are not ground truth — always review before including in a new version |

--- a/skills/training-and-evaluation/improvement-playbook.md
+++ b/skills/training-and-evaluation/improvement-playbook.md
@@ -64,6 +64,7 @@ Model not good enough?
 
 | Action | How in Roboflow |
 |---|---|
+| **Production pipeline (active learning)** | If you have a deployed workflow, add a Dataset Upload block to pipe production images back to your project automatically. Best for capturing real-world distribution. See `roboflow://skills/training-and-evaluation/active-learning` |
 | Fork from Universe | Universe > find similar dataset > fork to your project. Adds labeled images directly |
 | AI Labeling | Upload unlabeled images > use AI-assisted labeling to annotate faster |
 | Augmentation | Version settings > enable flip, rotation, crop, mosaic, etc. to synthetically expand training set |
@@ -140,3 +141,7 @@ Both are mAP@50. Cast to number before comparing.
 6. **Train new model** -- Use previous version as checkpoint if prior model was decent
 7. **Compare** -- Check if mAP/precision/recall improved vs previous version
 8. **Repeat** -- Target: mAP >70% for production use (domain-dependent)
+
+## Related Pages
+
+- `roboflow://skills/training-and-evaluation/active-learning` — set up a production feedback loop with the Dataset Upload workflow block


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Improvements and refinements driven by the June 10 dogfooding session ("Self Serve Lunch -- Dogfood UX Flows"), where two specific gaps surfaced:

1. **No active learning guidance** — the agent had no skill to draw on when a user asked how to improve their model using production images, so it improvised (rolling its own random-sampling dataset upload logic in application code rather than using the Dataset Upload workflow block).
2. **Agent defaulted to `models_infer` for a new integration** — the inference skill's workflow preference wasn't strong enough to surface the benefits clearly for the single-model integration case.


Part of LEO-211
## Changes

### New: `skills/training-and-evaluation/active-learning.md`
Production feedback loop skill covering:
- The canonical pattern: add a Dataset Upload block to your existing inference workflow
- Three filtering strategies: low-confidence sampling, random sampling, class-based filtering
- Review → annotate → retrain cycle
- Connection to improvement playbook diagnostics
- Common mistakes to avoid (direct API calls, uploading every frame, skipping review)
- Points agents to `workflow_blocks_get_schema` for current block properties rather than hardcoding them

### Updated: `skills/training-and-evaluation/improvement-playbook.md`
- Added "Production pipeline (active learning)" as the first option under Insufficient Data, linking to the new skill. Previously only listed Universe fork, AI labeling, and augmentation.

### Updated: `skills/training-and-evaluation/SKILL.md`
- Expanded description to include active learning and production feedback loops.

### Updated: `skills/inference/SKILL.md` and `skills/inference/workflows.md`
- Replaced prescriptive "always/never" workflow guidance with benefits-led framing: composability, server-side optimizations, zero-friction extensibility (analogous to microservice vs point-to-point).
- Added explicit carve-out: use `models_infer` when the user explicitly asks for direct inference or needs a quick check.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e2899d7-865f-4a9b-bfe0-53370899d42f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e2899d7-865f-4a9b-bfe0-53370899d42f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

