### PR TITLE
ci(agent-install): matrix publish to US + EU buckets

### DIFF
--- a/.github/workflows/publish-agent-install.yml
+++ b/.github/workflows/publish-agent-install.yml
@@ -22,15 +22,54 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Requiring an environment lets us add manual approval / restrict to main
-    # via the repo's environment protection rules without touching this file.
-    environment: agent-install-prod
+    strategy:
+      # Don't let one region's failure abort the others; each target is
+      # independent (different GCP project + WIF binding + bucket).
+      fail-fast: false
+      matrix:
+        include:
+          # US prod (existing behavior — unchanged).
+          - name: us-prod
+            bucket_name: roboflow-platform-agent-install
+            project: roboflow-platform
+            oidc_project_id: "481589474394"
+            service_account: gha-computer-vision-skills
+            wif_pool_id: github-actions
+            # Requiring an environment lets us add manual approval / restrict to
+            # main via the repo's environment protection rules without touching
+            # this file. Only US prod has an environment defined today.
+            environment: agent-install-prod
+          # EU staging. Depends on roboflow-infra PR #2208, which creates the
+          # gha-computer-vision-skills SA + WIF binding in roboflow-eu-staging.
+          # No GitHub environment is set: a non-existent environment: would
+          # block the job. Create an agent-install-eu-staging environment later
+          # if approval gating is desired.
+          - name: eu-staging
+            bucket_name: roboflow-eu-staging-agent-install
+            project: roboflow-eu-staging
+            oidc_project_id: "1044450058029"
+            service_account: gha-computer-vision-skills
+            wif_pool_id: github-actions
+            environment: ""
+          # EU prod. Depends on roboflow-infra PR #2208, which creates the
+          # gha-computer-vision-skills SA + WIF binding in roboflow-eu-platform.
+          # No GitHub environment is set (see eu-staging note above).
+          - name: eu-prod
+            bucket_name: roboflow-eu-platform-agent-install
+            project: roboflow-eu-platform
+            oidc_project_id: "563150022949"
+            service_account: gha-computer-vision-skills
+            wif_pool_id: github-actions
+            environment: ""
+    name: publish (${{ matrix.name }})
+    # When matrix.environment is "", GitHub treats this as no environment gate.
+    environment: ${{ matrix.environment }}
     env:
-      BUCKET_NAME: roboflow-platform-agent-install
-      PROJECT: roboflow-platform
-      OIDC_PROJECT_ID: "481589474394"
-      SERVICE_ACCOUNT: gha-computer-vision-skills
-      WIF_POOL_ID: github-actions
+      BUCKET_NAME: ${{ matrix.bucket_name }}
+      PROJECT: ${{ matrix.project }}
+      OIDC_PROJECT_ID: ${{ matrix.oidc_project_id }}
+      SERVICE_ACCOUNT: ${{ matrix.service_account }}
+      WIF_POOL_ID: ${{ matrix.wif_pool_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-agent-install.yml
+++ b/.github/workflows/publish-agent-install.yml
@@ -41,9 +41,10 @@ jobs:
             environment: agent-install-prod
           # EU staging. Depends on roboflow-infra PR #2208, which creates the
           # gha-computer-vision-skills SA + WIF binding in roboflow-eu-staging.
-          # No GitHub environment is set: a non-existent environment: would
-          # block the job. Create an agent-install-eu-staging environment later
-          # if approval gating is desired.
+          # environment is intentionally "" (no gate). Note: referencing a
+          # non-existent environment does NOT block the job — GitHub auto-creates
+          # it with no protection rules — so add a protected
+          # agent-install-eu-staging environment if approval gating is desired.
           - name: eu-staging
             bucket_name: roboflow-eu-staging-agent-install
             project: roboflow-eu-staging


### PR DESCRIPTION
# Description

Publish the agent-install assets (`agent-install/agent.sh`, `agent-install/agent.ps1`) to the **EU** GCS buckets in addition to the existing US prod bucket. This is the cross-repo half of **Gap B** for the Roboflow EU data-residency project: today these installers are only published to US infra, so EU customers fetching them go through US-region storage.

The single hardcoded publish job is refactored into a `fail-fast: false` matrix over three targets. **US prod behavior is unchanged** — same bucket, project, OIDC project ID, service account, WIF pool, and the `agent-install-prod` GitHub environment gate; only the values now come from the matrix instead of a job-level `env:` block.

### Publish targets

| Target | Bucket | Project | OIDC project ID | Service account | Environment gate |
| --- | --- | --- | --- | --- | --- |
| US prod (existing) | `roboflow-platform-agent-install` | `roboflow-platform` | `481589474394` | `gha-computer-vision-skills@roboflow-platform.iam.gserviceaccount.com` | `agent-install-prod` |
| EU staging (new) | `roboflow-eu-staging-agent-install` | `roboflow-eu-staging` | `1044450058029` | `gha-computer-vision-skills@roboflow-eu-staging.iam.gserviceaccount.com` | none (see below) |
| EU prod (new) | `roboflow-eu-platform-agent-install` | `roboflow-eu-platform` | `563150022949` | `gha-computer-vision-skills@roboflow-eu-platform.iam.gserviceaccount.com` | none (see below) |

`WIF_POOL_ID` is `github-actions` for all three; the provider path stays `projects/${OIDC_PROJECT_ID}/locations/global/workloadIdentityPools/${WIF_POOL_ID}/providers/github`.

### Infra dependency — roboflow-infra #2208 (REQUIRED before the EU legs can succeed)

The EU staging and EU prod legs authenticate via per-project WIF bindings + the `gha-computer-vision-skills` service account in `roboflow-eu-staging` / `roboflow-eu-platform`. **Those SAs and WIF bindings are created in roboflow-infra PR #2208.** Until #2208 merges and applies, the two EU matrix legs will fail to authenticate. `fail-fast: false` ensures that failure does **not** abort the US prod publish.

### GitHub environments

The US prod leg keeps its `agent-install-prod` environment gate. The EU legs intentionally run with **no** environment (`environment: ""`), because a `environment:` pointing at a non-existent environment would block the job from ever running. If approval gating is wanted for EU later, create `agent-install-eu-staging` / `agent-install-eu-prod` environments in repo settings and wire them into the matrix `environment` values.

### ⚠️ Data-residency follow-up (surfaced, not blocking)

I checked `agent-install/agent.sh` and `agent-install/agent.ps1` for hardcoded US hosts. **Today these are placeholder scripts** — the only executable content is `set -euo pipefail` + an `echo` (sh) / `$ErrorActionPreference` + a `Write-Host` (ps1), with a `# TODO: install logic` marker. The only `*.roboflow.com` references are `https://repo.roboflow.com/agent-install/...` in the header comments and usage examples (the US serving URL), **not in any executed install logic**, so there is nothing to make configurable yet.

**However:** once real install logic lands, if it hardcodes US hosts (`repo.roboflow.com`, `app.roboflow.com`, `api.roboflow.com`, etc.), the EU-published copies in these new buckets would send EU devices back to US infra — a data-residency leak. **The install logic must be region-aware (configurable host / EU defaults) before it ships to the EU buckets.** Flagging now so it isn't missed when the placeholders are filled in.

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Validated the workflow parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-agent-install.yml'))"` → OK, with matrix legs `us-prod`, `eu-staging`, `eu-prod`.
- Confirmed via `git diff` that the US prod leg is value-for-value identical to the previous hardcoded job (bucket, project, OIDC ID, SA, WIF pool, environment).
- Not run: per project policy the workflow was not triggered. The EU legs cannot succeed until roboflow-infra #2208 is applied.

## Any specific deployment considerations

- **Blocked on roboflow-infra #2208** for the EU SAs + WIF bindings; merging this PR before #2208 applies will produce two (non-fatal, `fail-fast: false`) failing EU legs.
- EU GCS buckets `roboflow-eu-staging-agent-install` / `roboflow-eu-platform-agent-install` must exist (tracked alongside the EU infra work).
- See the data-residency follow-up above before populating the installer scripts with real logic.

## Docs

-   [ ] Docs updated? What were the changes: n/a
