### PR TITLE
Reference trainings_create instead of models_train in skill docs

### DIFF
--- a/skills/api-reference/rest-api.md
+++ b/skills/api-reference/rest-api.md
@@ -2,7 +2,7 @@
 
 > **Source-of-truth note:** This page ships with the Roboflow plugin. If your client has the plugin loaded, prefer the local skill (`roboflow:api-reference`) over fetching `roboflow://skills/api-reference/rest-api` via `ReadMcpResourceTool` — the MCP resources are a fallback for non-plugin clients and may lag the source repo.
 
-> **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), prefer its tools (`projects_*`, `versions_*`, `images_*`, `annotations_save`, `models_train`, …) over raw REST calls — they handle auth and typed responses for you. The REST patterns below stay relevant if you're not using MCP.
+> **Tip:** If you're connected to the [Roboflow MCP server](https://mcp.roboflow.com), prefer its tools (`projects_*`, `versions_*`, `images_*`, `annotations_save`, `trainings_create`, …) over raw REST calls — they handle auth and typed responses for you. The REST patterns below stay relevant if you're not using MCP.
 
 Base URL: `https://api.roboflow.com`
 

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -50,7 +50,7 @@ description: Deployment option comparison (serverless, dedicated, self-hosted, b
 | `models_list` | List trained models for a project |
 | `models_get` | Get details for a trained model |
 | `models_infer` | Run single-model inference on one image via serverless API |
-| `models_train` | Start training a model on a dataset version |
+| `trainings_create` | Start training a model on a dataset version |
 | `models_get_training_status` | Check training progress and metrics |
 | **`workflows_run`** | **Preferred.** Run a saved workflow by `workflow_id` (the workflow URL slug; workspace is inferred from the API key — see [Finding your workspace slug](./workflows.md#finding-your-workspace-slug)). Optional `parameters`. |
 | `workflow_specs_validate` | Validate an inline workflow spec without running it — use before any inline run. |

--- a/skills/product-navigation/features-by-page.md
+++ b/skills/product-navigation/features-by-page.md
@@ -56,10 +56,10 @@ Base URL: `https://app.roboflow.com`
 
 | Intent | Web URL | Alternatives |
 |--------|---------|-------------|
-| Train a model | `/{ws}/{proj}/train` | MCP: `models_train` |
-| Choose model architecture | `/{ws}/{proj}/train` -> architecture step | MCP: `models_train` (model param) |
-| Train from checkpoint | `/{ws}/{proj}/train` -> checkpoint step | MCP: `models_train` |
-| Train specific version | `/{ws}/{proj}/{version}/train` | MCP: `models_train` |
+| Train a model | `/{ws}/{proj}/train` | MCP: `trainings_create` |
+| Choose model architecture | `/{ws}/{proj}/train` -> architecture step | MCP: `trainings_create` (model param) |
+| Train from checkpoint | `/{ws}/{proj}/train` -> checkpoint step | MCP: `trainings_create` |
+| Train specific version | `/{ws}/{proj}/{version}/train` | MCP: `trainings_create` |
 | Check training status | `/{ws}/{proj}/{version}` (shows progress bar) | MCP: `models_get_training_status` |
 | View training results (mAP, etc.) | `/{ws}/{proj}/{version}/train/results` | MCP: `models_get` |
 | Cancel training | `/{ws}/{proj}/{version}` -> Cancel button | -- |

--- a/skills/training-and-evaluation/SKILL.md
+++ b/skills/training-and-evaluation/SKILL.md
@@ -272,7 +272,7 @@ Auto-runs after training. Access: Models > click model version > View Evaluation
 | Action | Tool |
 |---|---|
 | Generate version | `versions_generate` |
-| Start training | `models_train` |
+| Start training | `trainings_create` (or compatibility alias `models_train`) |
 | Check training status | `models_get_training_status` |
 | Get model info | `models_get` |
 | List models | `models_list` |


### PR DESCRIPTION
## Summary

Skill docs told MCP clients to call `models_train`, but the tool on the MCP server is named `trainings_create`. During OpenAI's review their agent followed the docs and hit tool-not-found failures. This updates the four docs that referenced the wrong name. The server also ships a `models_train` compatibility alias, noted in the training skill.

## Changes

- `skills/inference/SKILL.md`, `skills/api-reference/rest-api.md`, `skills/product-navigation/features-by-page.md`: reference `trainings_create`
- `skills/training-and-evaluation/SKILL.md`: reference `trainings_create` with `models_train` noted as a compatibility alias

Made with [Cursor](https://cursor.com)