### PR TITLE
feat: custom-weights-upload skill (client-side SDK recipe)

### DIFF
--- a/skills/custom-weights-upload/SKILL.md
+++ b/skills/custom-weights-upload/SKILL.md
@@ -51,15 +51,23 @@ environment used for training (it already has `torch` and the matching
    `set -a; source .env; set +a` is fine. For a pre-existing `.env`, never
    `source` it — sourcing executes any shell in the file and exports every
    other secret it holds into the process. Read only the one key instead,
-   e.g. `python-dotenv` in the script:
-   `os.environ["ROBOFLOW_API_KEY"] = dotenv_values(".env")["ROBOFLOW_API_KEY"]`.
+   e.g. with `python-dotenv` (`pip install python-dotenv`) in the script:
+
+   ```python
+   import os
+   from dotenv import dotenv_values
+
+   os.environ["ROBOFLOW_API_KEY"] = dotenv_values(".env")["ROBOFLOW_API_KEY"]
+   ```
 
    Scope the key for the whole deploy flow, not minimally: the SDK's
    `rf.workspace()` reads the workspace and its project list before
    deploying, so `project:read` plus `model:deploy` alone fails with missing
    permissions. Include `workspace:read`, `project:read`, `model:deploy`,
-   and for a versioned deploy also `version:read` and `version:update`. The
-   preflight below verifies the scopes before anything heavy runs.
+   and for a versioned deploy also `version:read` and `version:update`.
+   Getting the scopes right at mint time is what protects the upload: the
+   preflight below only confirms the key and the workspace read, not the
+   deploy scope.
 
    If the `api_keys_create` call is denied (permission systems may flag
    credential creation during an upload task) or unavailable, do not work

--- a/skills/custom-weights-upload/SKILL.md
+++ b/skills/custom-weights-upload/SKILL.md
@@ -47,8 +47,12 @@ environment used for training (it already has `torch` and the matching
    and it returns it once (`api_keys_list` / `api_keys_get` return masked
    metadata) — and write it yourself to a `.gitignore`'d `.env` as
    `ROBOFLOW_API_KEY`. Writing `.env` does not populate `os.environ`: load it
-   before running, e.g. `set -a; source .env; set +a` in the shell, or
-   `python-dotenv` in the script.
+   before running. For a `.env` you just wrote yourself,
+   `set -a; source .env; set +a` is fine. For a pre-existing `.env`, never
+   `source` it — sourcing executes any shell in the file and exports every
+   other secret it holds into the process. Read only the one key instead,
+   e.g. `python-dotenv` in the script:
+   `os.environ["ROBOFLOW_API_KEY"] = dotenv_values(".env")["ROBOFLOW_API_KEY"]`.
 
    Scope the key for the whole deploy flow, not minimally: the SDK's
    `rf.workspace()` reads the workspace and its project list before
@@ -78,8 +82,8 @@ report every gap at once instead of failing one step at a time:
 2. Required imports load: `torch` for YOLO, RF-DETR, and YOLO-NAS;
    `ultralytics` for YOLO v8/v10/v11/v12/26; `rfdetr>=1.8.0` for raw
    PyTorch-Lightning RF-DETR checkpoints.
-3. The key works and carries enough scope — one cheap call that exercises
-   the same workspace read `deploy_model` needs:
+3. The key is valid and covers the workspace read — one cheap call that
+   exercises the same workspace/project-list read `deploy_model` starts with:
 
    ```python
    import os
@@ -87,6 +91,12 @@ report every gap at once instead of failing one step at a time:
 
    Roboflow(api_key=os.environ["ROBOFLOW_API_KEY"]).workspace()
    ```
+
+   Be honest about the limit of this check: it does not exercise
+   `model:deploy`, which the platform only tests at `models/prepareUpload`,
+   after packaging. That is why step 2 mints the key with the full scope set
+   up front — the preflight catches a bad or under-read key, not a missing
+   deploy scope on an existing key.
 
 Only package and upload after all three pass.
 

--- a/skills/custom-weights-upload/SKILL.md
+++ b/skills/custom-weights-upload/SKILL.md
@@ -82,20 +82,34 @@ version.deploy(
 
 `model_type` must name the real architecture (`yolov8n`, `yolov11s`,
 `rfdetr-base`, `rfdetr-seg-medium`, `yolonas`, a supported PaliGemma or
-Florence-2 type). The SDK infers the size or variant from the weights. On a
-dependency or size mismatch, `deploy_model` / `version.deploy` print the
-error (it names the type that fits) and then **interactively prompt**
-"Would you like to continue anyway? y/n" — in a headless run that prompt
-surfaces as an `EOFError` right after the printed mismatch. Either way, treat
-it as "fix `model_type` to the named one and rerun". Never pipe a `y` into
-the prompt to force past a mismatch unless the user has explicitly confirmed
-the override is intentional.
+Florence-2 type). For YOLO families the SDK infers a missing size suffix
+from the weights; RF-DETR accepts no bare `rfdetr` — pass the exact variant,
+which the SDK cross-checks against the checkpoint.
+
+On a size/variant or dependency mismatch, `deploy_model` / `version.deploy`
+print the error and then **interactively prompt** "Would you like to continue
+anyway? y/n" — in a headless run the prompt surfaces as an `EOFError` right
+after the printed error. Recover by error type:
+
+- **Size/variant mismatch**: when the error names the type that fits, fix
+  `model_type` to it and rerun; when it says the size could not be inferred,
+  pass an explicit size.
+- **Dependency mismatch**: the error names a pip pin, not a model type
+  (`yolov8` recommends `ultralytics==8.0.196`, so most current training
+  environments hit this prompt). Install the named version, or — only with
+  the user's explicit confirmation — answer `y` (headless:
+  `printf 'y\n' | python upload.py`) to continue with the installed version.
+
+Never force past either prompt without the user explicitly confirming the
+override is intentional.
 
 ## Per-family requirements
 
-- **YOLO (v5–v12, YOLO26)**: needs `torch` and `ultralytics` importable. The
-  SDK enforces recommended `ultralytics` versions, another reason to run in
-  the training environment.
+- **YOLO v8/v10/v11/v12/YOLO26**: needs `torch` and `ultralytics` importable
+  (`yolov8` recommends `ultralytics==8.0.196`; see the dependency-mismatch
+  note above). **Legacy YOLO v5/v7/v9**: needs `torch` plus an `opt.yaml` in
+  `model_path` with `imgsz` (or `img_size`) and `batch_size`; `ultralytics`
+  is not used. There is no yolov6 support.
 - **RF-DETR**: needs `torch` to read the checkpoint. If a `class_names.txt`
   (one class per line) sits in `model_path` it is used; otherwise class names
   come from the checkpoint's `args`. Raw PyTorch-Lightning checkpoints

--- a/skills/custom-weights-upload/SKILL.md
+++ b/skills/custom-weights-upload/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: roboflow-custom-weights-upload
+description: Use when uploading locally trained model weights (YOLO, RF-DETR, YOLO-NAS, PaliGemma, Florence-2) to Roboflow — choosing between the hosted MCP tool and the client-side Python SDK flow, safe API key handling, per-family packaging requirements, and verifying the upload.
+---
+
+> **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
+
+# Custom Weights Upload
+
+Register weights from a model trained outside Roboflow (a laptop, a training
+server, Colab) so Roboflow can convert, host, and serve it.
+
+## First decide where the upload must run
+
+Packaging reads the checkpoint from disk, so it must run on the machine that
+has the weights.
+
+- The `models_upload_custom_weights` MCP tool reads `model_path` from the
+  **MCP server's filesystem**. When you are connected to the hosted Roboflow
+  MCP server (`mcp.roboflow.com`), it cannot see files on the user's machine.
+  This is the common case: weights on the user's machine plus a hosted server
+  means **do not call the tool** — run the client-side SDK flow below.
+- Call the tool only when the MCP server runs on the same machine as the
+  weights: a locally running dev server, or weights that already live on the
+  server host.
+
+Calling the tool with a path the server cannot see fails with a clear error
+pointing back to this skill; nothing is uploaded.
+
+## Client-side upload with the Python SDK
+
+Run this on the machine that has the weights, ideally in the same Python
+environment used for training (it already has `torch` and the matching
+`ultralytics`).
+
+1. **Install the SDK**: `pip install "roboflow>=1.3.13"`.
+2. **Handle the API key safely**: never ask the user to paste a private API
+   key into chat. Retrieve one with the MCP `api_keys_list` / `api_keys_get`
+   tools (or mint a scoped one with `api_keys_create`), write it to a
+   `.gitignore`'d `.env` as `ROBOFLOW_API_KEY`, and read it from the
+   environment.
+3. **Confirm the destination with the user**: registering a model is not
+   easily undone. Never infer the target project or version from the
+   checkpoint's class count or filename — ask.
+
+Workspace model upload (no dataset version required):
+
+```python
+import os
+from roboflow import Roboflow
+
+rf = Roboflow(api_key=os.environ["ROBOFLOW_API_KEY"])
+workspace = rf.workspace("WORKSPACE_SLUG")
+workspace.deploy_model(
+    model_type="rfdetr-base",
+    model_path="/path/to/training/output",
+    project_ids=["PROJECT_SLUG"],
+    model_name="MODEL_NAME",
+    filename="checkpoint_best_total.pth",  # relative to model_path
+)
+```
+
+Versioned deploy (attach weights to an existing dataset version):
+
+```python
+import os
+from roboflow import Roboflow
+
+rf = Roboflow(api_key=os.environ["ROBOFLOW_API_KEY"])
+version = rf.workspace("WORKSPACE_SLUG").project("PROJECT_SLUG").version(3)
+version.deploy(
+    model_type="yolov8n",
+    model_path="/path/to/runs/detect/train",
+    filename="weights/best.pt",
+)
+```
+
+`model_type` must name the real architecture (`yolov8n`, `yolov11s`,
+`rfdetr-base`, `rfdetr-seg-medium`, `yolonas`, a supported PaliGemma or
+Florence-2 type). The SDK infers the size or variant from the weights and, on
+a mismatch, raises an error naming the one that fits — fix `model_type`
+rather than passing a guess and hoping server-side conversion sorts it out.
+
+## Per-family requirements
+
+- **YOLO (v5–v12, YOLO26)**: needs `torch` and `ultralytics` importable. The
+  SDK enforces recommended `ultralytics` versions, another reason to run in
+  the training environment.
+- **RF-DETR**: needs `torch` to read the checkpoint. If a `class_names.txt`
+  (one class per line) sits in `model_path` it is used; otherwise class names
+  come from the checkpoint's `args`. An explicit `filename` that does not
+  exist is a hard error; the default `weights/best.pt` falls back to the
+  first top-level `.pt`/`.pth` file, with a warning.
+- **YOLO-NAS**: `model_type="yolonas"` plus an `opt.yaml` in `model_path`
+  with `imgsz`, `batch_size`, and `architecture`.
+- **PaliGemma / Florence-2**: `model_path` is the Hugging Face save directory
+  (config, tokenizer, and weights files); no `torch` needed.
+
+## Verify the upload
+
+Conversion runs server-side after the upload and usually takes a few minutes.
+Check it with the MCP `models_list` / `models_get` tools or at
+`app.roboflow.com/WORKSPACE/PROJECT/models`, then run a test inference on a
+sample image to confirm classes and predictions look right.

--- a/skills/custom-weights-upload/SKILL.md
+++ b/skills/custom-weights-upload/SKILL.md
@@ -33,7 +33,10 @@ Run this on the machine that has the weights, ideally in the same Python
 environment used for training (it already has `torch` and the matching
 `ultralytics`).
 
-1. **Install the SDK**: `pip install "roboflow>=1.3.13"`.
+1. **Install the SDK**: both `roboflow>=1.3.13` and `rfdetr` require
+   **Python >= 3.10**; check `python3 --version` first (macOS ships 3.9). If
+   it is too old, create a venv: `uv venv --python 3.12 && source
+   .venv/bin/activate`. Then `pip install "roboflow>=1.3.13"`.
 2. **Handle the API key safely**: never ask the user to paste a private API
    key into chat, and never scan dotfiles, shell profiles, or config files
    hunting for one — permission systems rightly block that. If
@@ -47,15 +50,45 @@ environment used for training (it already has `torch` and the matching
    before running, e.g. `set -a; source .env; set +a` in the shell, or
    `python-dotenv` in the script.
 
+   Scope the key for the whole deploy flow, not minimally: the SDK's
+   `rf.workspace()` reads the workspace and its project list before
+   deploying, so `project:read` plus `model:deploy` alone fails with missing
+   permissions. Include `workspace:read`, `project:read`, `model:deploy`,
+   and for a versioned deploy also `version:read` and `version:update`. The
+   preflight below verifies the scopes before anything heavy runs.
+
    If the `api_keys_create` call is denied (permission systems may flag
    credential creation during an upload task) or unavailable, do not work
    around the denial. Ask the user to choose: (a) explicitly authorize
    minting a temporary scoped key, which you revoke with `api_keys_revoke`
    after the upload; (b) set `ROBOFLOW_API_KEY` themselves in their shell or
    a `.env`; or (c) point you at an existing `.env` that already defines it.
-3. **Confirm the destination with the user**: registering a model is not
-   easily undone. Never infer the target project or version from the
-   checkpoint's class count or filename — ask.
+3. **Confirm the destination and the name with the user**: registering a
+   model is not easily undone. Never infer the target project or version from
+   the checkpoint's class count or filename — ask. The same goes for
+   `model_name` on a workspace upload: ask the user what the model should be
+   called; do not invent a name.
+
+### Preflight before packaging
+
+Packaging plus a 100 MB+ upload is slow; run the cheap checks first and
+report every gap at once instead of failing one step at a time:
+
+1. Python is >= 3.10 (`python3 --version`).
+2. Required imports load: `torch` for YOLO, RF-DETR, and YOLO-NAS;
+   `ultralytics` for YOLO v8/v10/v11/v12/26; `rfdetr>=1.8.0` for raw
+   PyTorch-Lightning RF-DETR checkpoints.
+3. The key works and carries enough scope — one cheap call that exercises
+   the same workspace read `deploy_model` needs:
+
+   ```python
+   import os
+   from roboflow import Roboflow
+
+   Roboflow(api_key=os.environ["ROBOFLOW_API_KEY"]).workspace()
+   ```
+
+Only package and upload after all three pass.
 
 Workspace model upload (no dataset version required):
 

--- a/skills/custom-weights-upload/SKILL.md
+++ b/skills/custom-weights-upload/SKILL.md
@@ -35,15 +35,17 @@ environment used for training (it already has `torch` and the matching
 
 1. **Install the SDK**: `pip install "roboflow>=1.3.13"`.
 2. **Handle the API key safely**: never ask the user to paste a private API
-   key into chat. Prefer a key already available on the machine (a
-   `ROBOFLOW_API_KEY` environment variable or an existing gitignored `.env`).
-   Otherwise mint a scoped key with the MCP `api_keys_create` tool — the only
-   `api_keys` tool that returns the secret, and it returns it once
-   (`api_keys_list` / `api_keys_get` return masked metadata) — and write it
-   yourself to a `.gitignore`'d `.env` as `ROBOFLOW_API_KEY`. Writing `.env`
-   does not populate `os.environ`: load it before running, e.g.
-   `set -a; source .env; set +a` in the shell, or `python-dotenv` in the
-   script.
+   key into chat, and never scan dotfiles, shell profiles, or config files
+   hunting for one — permission systems rightly block that. If
+   `ROBOFLOW_API_KEY` is already set in the environment
+   (`test -n "$ROBOFLOW_API_KEY"`) or the working project has a `.env` that
+   defines it, use it. Otherwise mint a scoped key with the MCP
+   `api_keys_create` tool — the only `api_keys` tool that returns the secret,
+   and it returns it once (`api_keys_list` / `api_keys_get` return masked
+   metadata) — and write it yourself to a `.gitignore`'d `.env` as
+   `ROBOFLOW_API_KEY`. Writing `.env` does not populate `os.environ`: load it
+   before running, e.g. `set -a; source .env; set +a` in the shell, or
+   `python-dotenv` in the script.
 3. **Confirm the destination with the user**: registering a model is not
    easily undone. Never infer the target project or version from the
    checkpoint's class count or filename — ask.

--- a/skills/custom-weights-upload/SKILL.md
+++ b/skills/custom-weights-upload/SKILL.md
@@ -46,6 +46,13 @@ environment used for training (it already has `torch` and the matching
    `ROBOFLOW_API_KEY`. Writing `.env` does not populate `os.environ`: load it
    before running, e.g. `set -a; source .env; set +a` in the shell, or
    `python-dotenv` in the script.
+
+   If the `api_keys_create` call is denied (permission systems may flag
+   credential creation during an upload task) or unavailable, do not work
+   around the denial. Ask the user to choose: (a) explicitly authorize
+   minting a temporary scoped key, which you revoke with `api_keys_revoke`
+   after the upload; (b) set `ROBOFLOW_API_KEY` themselves in their shell or
+   a `.env`; or (c) point you at an existing `.env` that already defines it.
 3. **Confirm the destination with the user**: registering a model is not
    easily undone. Never infer the target project or version from the
    checkpoint's class count or filename — ask.

--- a/skills/custom-weights-upload/SKILL.md
+++ b/skills/custom-weights-upload/SKILL.md
@@ -35,10 +35,15 @@ environment used for training (it already has `torch` and the matching
 
 1. **Install the SDK**: `pip install "roboflow>=1.3.13"`.
 2. **Handle the API key safely**: never ask the user to paste a private API
-   key into chat. Retrieve one with the MCP `api_keys_list` / `api_keys_get`
-   tools (or mint a scoped one with `api_keys_create`), write it to a
-   `.gitignore`'d `.env` as `ROBOFLOW_API_KEY`, and read it from the
-   environment.
+   key into chat. Prefer a key already available on the machine (a
+   `ROBOFLOW_API_KEY` environment variable or an existing gitignored `.env`).
+   Otherwise mint a scoped key with the MCP `api_keys_create` tool — the only
+   `api_keys` tool that returns the secret, and it returns it once
+   (`api_keys_list` / `api_keys_get` return masked metadata) — and write it
+   yourself to a `.gitignore`'d `.env` as `ROBOFLOW_API_KEY`. Writing `.env`
+   does not populate `os.environ`: load it before running, e.g.
+   `set -a; source .env; set +a` in the shell, or `python-dotenv` in the
+   script.
 3. **Confirm the destination with the user**: registering a model is not
    easily undone. Never infer the target project or version from the
    checkpoint's class count or filename — ask.
@@ -77,9 +82,14 @@ version.deploy(
 
 `model_type` must name the real architecture (`yolov8n`, `yolov11s`,
 `rfdetr-base`, `rfdetr-seg-medium`, `yolonas`, a supported PaliGemma or
-Florence-2 type). The SDK infers the size or variant from the weights and, on
-a mismatch, raises an error naming the one that fits — fix `model_type`
-rather than passing a guess and hoping server-side conversion sorts it out.
+Florence-2 type). The SDK infers the size or variant from the weights. On a
+dependency or size mismatch, `deploy_model` / `version.deploy` print the
+error (it names the type that fits) and then **interactively prompt**
+"Would you like to continue anyway? y/n" — in a headless run that prompt
+surfaces as an `EOFError` right after the printed mismatch. Either way, treat
+it as "fix `model_type` to the named one and rerun". Never pipe a `y` into
+the prompt to force past a mismatch unless the user has explicitly confirmed
+the override is intentional.
 
 ## Per-family requirements
 
@@ -88,7 +98,9 @@ rather than passing a guess and hoping server-side conversion sorts it out.
   the training environment.
 - **RF-DETR**: needs `torch` to read the checkpoint. If a `class_names.txt`
   (one class per line) sits in `model_path` it is used; otherwise class names
-  come from the checkpoint's `args`. An explicit `filename` that does not
+  come from the checkpoint's `args`. Raw PyTorch-Lightning checkpoints
+  additionally need `rfdetr>=1.8.0` installed (the SDK's error names the
+  exact minimum if yours is older). An explicit `filename` that does not
   exist is a hard error; the default `weights/best.pt` falls back to the
   first top-level `.pt`/`.pth` file, with a warning.
 - **YOLO-NAS**: `model_type="yolonas"` plus an `opt.yaml` in `model_path`


### PR DESCRIPTION
## What this adds

A new `custom-weights-upload` skill that teaches agents how to upload locally trained model weights to Roboflow.

## Why

The `models_upload_custom_weights` MCP tool reads `model_path` from the MCP server's own filesystem. In practice almost every real session is the hosted MCP server (mcp.roboflow.com) plus weights on the user's machine, and in that combination the tool cannot see the file. Without guidance, agents improvise. Real test sessions produced all of these: minutes burned rediscovering the SDK fallback, dotfiles scanned for credentials (rightly blocked by permission systems), a private API key pasted into chat, an invented model name, a dead end on the SDK's interactive mismatch prompt, and a 127 MB upload attempted before finding out the key lacked scopes.

## What the skill covers

- **Where the upload must run.** Packaging reads the checkpoint from disk, so hosted server plus local weights means the client-side SDK flow, not the tool. The tool is only for servers that can read the path.
- **Preflight before packaging.** Python >= 3.10 (recommend `uv venv --python 3.12` when the system Python is older; both `roboflow>=1.3.13` and `rfdetr` require 3.10+), required imports (`torch`; `ultralytics` for YOLO v8/v10/v11/v12/26; `rfdetr>=1.8.0` for raw PyTorch-Lightning checkpoints), and a cheap `rf.workspace()` call that validates the key and the workspace read. That call cannot exercise `model:deploy` (the platform only tests it at `models/prepareUpload`, after packaging), which is why the key is minted with the full scope set up front. All checks run before any 100 MB+ packaging or upload, so gaps surface as one report instead of serial failures.
- **Safe API key handling.** Use `ROBOFLOW_API_KEY` from the environment or an existing `.env` first; never scan dotfiles or shell profiles. Otherwise mint a scoped key with `api_keys_create`, the only `api_keys` tool that returns the secret (list/get return masked metadata), and write it to a gitignored `.env` (loading it explicitly, since writing `.env` does not populate `os.environ`). If key creation is denied by a permission system, do not work around it: offer the user three options (authorize a temporary key revoked after upload via `api_keys_revoke`, set the env var themselves, or point at an existing `.env`).
- **Scopes that actually work.** The SDK's `rf.workspace()` reads the workspace and its project list before deploying, so `project:read` plus `model:deploy` alone fails with missing permissions. The skill lists the working set: `workspace:read`, `project:read`, `model:deploy`, plus `version:read`/`version:update` for versioned deploys.
- **Correct SDK calls**, verified against roboflow 1.3.13: `workspace.deploy_model(model_type, model_path, project_ids, model_name, filename)` and `project.version(N).deploy(model_type, model_path, filename)`.
- **Mismatch recovery split by error type.** `deploy_model`/`version.deploy` prompt interactively on size or dependency mismatches (headless runs surface `EOFError`). Size/variant mismatch: fix `model_type` to the one the error names. Dependency mismatch (e.g. `yolov8` recommends `ultralytics==8.0.196`, which most current training environments trip on): install the named pin, or continue past the prompt only with the user's explicit confirmation.
- **Per-family requirements.** YOLO v8/v10/v11/v12/26 (torch + ultralytics), legacy YOLO v5/v7/v9 (torch + `opt.yaml` with `imgsz`/`img_size` and `batch_size`, no ultralytics, no yolov6 support), RF-DETR (torch always on 1.3.13; `rfdetr>=1.8.0` for PTL checkpoints; exact variant required, never bare `rfdetr`), YOLO-NAS (`opt.yaml`), PaliGemma/Florence-2 (HF directory, no torch).
- **Never infer the destination or the name.** Project, version, and `model_name` come from the user, not from the checkpoint's classes or filename.
- **Post-upload verification** with `models_list`/`models_get` and a test inference once server-side conversion finishes.

## Pairing

roboflow-mcp#115 reframes the upload tool's description and returns fail-forward errors pointing at this skill when `model_path` does not exist on the server or a packaging dependency is missing there. The MCP deploy workflow refreshes the `computer-vision-skills` submodule to latest main at build time, so this skill ships on the next MCP deploy after this merges. Merge this PR before roboflow-mcp#115.

