### PR TITLE
feat: batch-processing skill (ETL staging + jobs via inference-cli and MCP tools)

### DIFF
--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -68,10 +68,12 @@ write the user's disk:
 - **Exporting results** (`export-batch`) downloads into a local directory.
 
 Everything in between needs only an API key, so it works either way: the MCP
-tools (`batch_processing_run`, `_job_start`, `_job_get`, `_jobs_list`,
-`_job_logs`, `_job_abort`, `_job_restart`,
-`batch_processing_asset_library_*`, `batch_processing_staging_*`) or
-the equivalent CLI commands. Prefer the MCP tools when the host has no shell or the user has
+tools (`batch_processing_run`, `batch_processing_job_start`,
+`batch_processing_job_get`, `batch_processing_jobs_list`,
+`batch_processing_job_logs`, `batch_processing_job_abort`,
+`batch_processing_job_restart`, plus the
+`batch_processing_asset_library_*` and `batch_processing_staging_*`
+families) or the equivalent CLI commands. Prefer the MCP tools when the host has no shell or the user has
 no local `inference-cli`; prefer the CLI when the user is already in a
 terminal. The full command set for both content types is in sections 1-5.
 
@@ -316,7 +318,8 @@ shell can still fetch them. Export batches are multipart: the tool selects the
 part automatically when there is exactly one, and otherwise asks you to pass
 `part_name` (the parts are in `batch_processing_staging_batch_get`). Archives
 (`.tar` / `.tar.gz`) must be unpacked after download, and listings are capped
-at 10,000 entries per call — past that scale use `export-batch`, or import the
-source data into the workspace with datasources (ELT) and work inside Roboflow.
+at 10,000 entries per call — past that scale keep paginating with
+`nextPageToken` and per-part `part_name` listings, or pull everything with the
+resumable `export-batch`.
 
 Do this within 7 days: staged inputs and results expire.

--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roboflow-batch-processing
-description: Use when processing many Asset Library images or external images/videos with a Roboflow Workflow, including selecting Asset Library inputs, staging local or cloud files with the inference-cli, monitoring jobs, downloading results, and choosing between batch processing (ETL) and datasource bucket mirroring (ELT).
+description: Use when running a Roboflow Workflow over many images or videos with batch processing — Asset Library jobs (the platform stages workspace images for you) or staged jobs (you stage external local/cloud files with the inference-cli), plus monitoring jobs, downloading results, and routing imports to datasources (bucket mirror) instead.
 ---
 
 > **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
@@ -8,39 +8,40 @@ description: Use when processing many Asset Library images or external images/vi
 # Batch Processing
 
 Run a Roboflow Workflow over a very large set of images or videos on
-Roboflow's autoscaling compute. Existing Asset Library images use the
-platform-owned selection and staging pipeline. External files are staged into
-temporary Data Staging batches, processed, and exported back to staging for
-download without importing them into the workspace.
+Roboflow's autoscaling compute. Every job processes a temporary Data Staging
+batch; the two input paths differ only in **who fills that batch**:
 
-## Choose the input path first
+- **Asset Library job** — the files are already in Roboflow. You hand the
+  platform a selection and it selects and stages them for you.
+- **Staged job** — the files are outside Roboflow (local disk, cloud bucket,
+  references file), so you stage them yourself with the inference-cli: only
+  your machine and credentials can reach them. Nothing is imported into the
+  workspace, and staged data expires after ~7 days.
 
-- **Asset Library images:** call
-  `batch_processing_asset_library_job_create` with a stable idempotency key and
-  exactly one selection: `image_ids`, `query`, or `all_images=true`. The
-  platform performs access checks, selects the files, stages them, verifies
-  Workflow compatibility, bills, and registers the durable job. Poll the
-  returned `taskId` with `batch_processing_asset_library_task_get` until the
-  task is terminal; then monitor its `jobId` with `batch_processing_job_get`.
-- **Local, cloud, or reference-file inputs:** use
-  `batch_processing_guide` and `batch_processing_run` as described below. File
-  staging and result export must run on the machine that can access the files.
+## Which path? Three questions
 
-## Batch processing vs datasources (ETL vs ELT)
+1. **Are the files already in Roboflow (Asset Library)?** Call
+   `batch_processing_asset_library_job_create` with a stable idempotency key
+   and exactly one selection: `image_ids`, `query`, or `all_images=true`. The
+   platform performs access checks, selects the files, stages them, verifies
+   Workflow compatibility, bills, and registers the durable job. Poll the
+   returned `taskId` with `batch_processing_asset_library_task_get` until the
+   task is terminal; then monitor its `jobId` with `batch_processing_job_get`.
+2. **Files outside Roboflow, and you only want the outputs?** Stage them
+   yourself and drive the run with `batch_processing_guide` +
+   `batch_processing_run` as described below (the classic ETL shape: nothing
+   lands in the workspace). Staging and result export must run on the machine
+   that can access the files.
+3. **Files outside Roboflow that you want INSIDE it** (labeling, curation,
+   training)? That is an import, not a batch processing job: mirror the
+   bucket with a datasource (`connect_cloud_storage`, see the `cloud-storage`
+   skill). Once mirrored, the files are Asset Library images, so if you also
+   want bulk predictions, run an Asset Library job over them (the classic ELT
+   shape: load first, then transform).
 
-Two pipelines exist for "I have a ton of files in a bucket/on disk". Pick by
-what the user wants to end up with:
-
-- **Batch processing (this skill, ETL):** run a model/Workflow over the
-  files and get the results out. Nothing lands in the Roboflow workspace;
-  staged data expires after ~7 days. Best for one-off or recurring bulk
-  inference over local disks or cloud buckets.
-- **Datasources / bucket mirror (ELT, see the `cloud-storage` skill):**
-  import the files INTO the workspace first for labeling, curation, and
-  training, then work on them inside Roboflow.
-
-Rule of thumb: "process and give me the outputs" → batch processing;
-"get these into Roboflow" → datasources (`connect_cloud_storage`).
+"Datasource" and "bucket mirror" are one thing: a datasource is the
+user-facing name for a bucket-mirror config, the importer that fills the
+Asset Library. It never runs Workflows itself.
 
 ## Prerequisites
 
@@ -68,7 +69,7 @@ write the user's disk:
 - **Exporting results** (`export-batch`) downloads into a local directory.
 
 Everything in between needs only an API key, so it works either way: the MCP
-tools (`batch_processing_run`, `batch_processing_job_start`,
+tools (`batch_processing_run`, `batch_processing_staged_job_start`,
 `batch_processing_job_get`, `batch_processing_jobs_list`,
 `batch_processing_job_logs`, `batch_processing_job_abort`,
 `batch_processing_job_restart`, plus the
@@ -113,12 +114,12 @@ stored, or pass a new explicit `job_id` for a separate run.
 
 For the advanced knobs (`max_runtime_seconds`, `max_parallel_tasks`,
 `max_image_failure_rate`, `image_outputs_to_save`) use
-`batch_processing_job_start` directly.
+`batch_processing_staged_job_start` directly.
 
 ## Webhooks
 
 Roboflow will POST job and ingest notifications to a URL you control. There is
-no MCP-side relay: pass `notifications_url` to `batch_processing_job_start`, or
+no MCP-side relay: pass `notifications_url` to `batch_processing_staged_job_start`, or
 `--notifications-url` on the CLI commands, pointing at your own receiver. The
 POST carries an `Authorization` header with your publishable key.
 
@@ -233,7 +234,7 @@ video jobs). Videos only: `--max-video-fps <n>`.
 MCP equivalent:
 
 ```
-batch_processing_job_start(
+batch_processing_staged_job_start(
   job_id="my-stable-job-id",           # required; reuse for retries
   batch_id="my-batch", workflow_id="my-workflow",
   content_type="images",            # or "videos"
@@ -294,7 +295,9 @@ MCP equivalents, which return JSON rather than a rendered table:
   workers, timeout).
 - `batch_processing_jobs_list(search=...)` — the workspace's recent Workflow
   jobs, for finding a job id you did not keep. Internal TensorRT compilation
-  jobs are excluded.
+  jobs are excluded. Both this tool and `batch_processing_job_get` label each
+  job with `inputSource`: `asset-library` (platform-staged selection) or
+  `staged-batch` (a batch you staged yourself).
 
 ## 5. Download results
 

--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -43,6 +43,10 @@ batch; the two input paths differ only in **who fills that batch**:
 user-facing name for a bucket-mirror config, the importer that fills the
 Asset Library. It never runs Workflows itself.
 
+In pipeline terms: a staged job is the T of an ETL flow (no load ever
+happens), and an Asset Library job is the T of an ELT flow — the load
+already happened, via uploads or a datasource mirror.
+
 ## Prerequisites
 
 - The workspace needs the batch-processing feature. Gated calls fail with a

--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -37,9 +37,12 @@ Rule of thumb: "process and give me the outputs" → batch processing;
 - The Workflow must already exist in the workspace (`workflows_list`,
   `workflows_create`). Jobs reference it by `workflow_id`; there is no
   inline-spec option.
-- API key: set `ROBOFLOW_API_KEY` in the environment (mint one with the
-  `api_keys_create` MCP tool). Never have the user paste a private key into
-  chat.
+- API key: the inference-cli reads `ROBOFLOW_API_KEY` from the environment,
+  and every command also accepts `--api-key=<key>`. A key stored by
+  `roboflow login` (`~/.config/roboflow/config.json`) is NOT picked up by
+  the inference-cli: export it or pass `--api-key` explicitly. Mint one with
+  the `api_keys_create` MCP tool. Never have the user paste a private key
+  into chat.
 
 ## Where each step runs, and why
 
@@ -112,6 +115,9 @@ pip install inference-cli
 # For s3:// gs:// az:// sources:
 pip install 'inference-cli[cloud-storage]'
 ```
+
+Every `inference rf-cloud` command below authenticates via `ROBOFLOW_API_KEY`
+from the environment, or `--api-key=<key>` on the command itself.
 
 Cloud credentials are picked up from the standard env chains on the machine
 running the CLI: AWS via the default credential chain (`AWS_PROFILE` honored;

--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -51,9 +51,9 @@ write the user's disk:
 - **Exporting results** (`export-batch`) downloads into a local directory.
 
 Everything in between needs only an API key, so it works either way: the MCP
-tools (`batch_processing_run`, `_job_start`, `_job_get`, `_job_logs`,
-`_job_abort`, `_job_restart`, `batch_processing_staging_*`) or the equivalent
-CLI commands. Prefer the MCP tools when the host has no shell or the user has
+tools (`batch_processing_run`, `_job_start`, `_job_get`, `_jobs_list`,
+`_job_logs`, `_job_abort`, `_job_restart`, `batch_processing_staging_*`) or
+the equivalent CLI commands. Prefer the MCP tools when the host has no shell or the user has
 no local `inference-cli`; prefer the CLI when the user is already in a
 terminal. The full command set for both content types is in sections 1-5.
 
@@ -81,9 +81,10 @@ returned `job_id` to resume. The server holds no state between calls.
 
 The job is started under an id derived from (workspace, batch, workflow), so
 retrying after a lost response re-registers the same job instead of paying for
-a second run. A 409 means that id already exists with genuinely different
-settings: either re-call with the original settings, or pass an explicit
-`job_id` for a separate run.
+a second run. (The platform checks credits before that idempotency comparison,
+so a retry can still see a 429 first.) A 409 means that id already exists with
+genuinely different settings: either re-call with the original settings, or
+pass an explicit `job_id` for a separate run.
 
 For the advanced knobs (`max_runtime_seconds`, `max_parallel_tasks`,
 `max_image_failure_rate`, `image_outputs_to_save`, `part_name`) use
@@ -97,8 +98,9 @@ no MCP-side relay: pass `notifications_url` to `batch_processing_job_start`, or
 POST carries an `Authorization` header with your publishable key.
 
 Caveat: local **video** staging does not support `--notifications-url` (the CLI
-prints a warning and drops it). Local image, cloud-storage and references-file
-ingests all support it.
+prints a warning and drops it), and a small local **image** batch (32 files or
+fewer stages as a simple batch) ignores it too. Sharded local image,
+cloud-storage and references-file ingests all support it.
 
 If you have no receiver, just poll `batch_processing_job_get` (or
 `batch_processing_run`, which reports progress on each call).
@@ -112,12 +114,14 @@ pip install 'inference-cli[cloud-storage]'
 ```
 
 Cloud credentials are picked up from the standard env chains on the machine
-running the CLI: AWS via the default credential chain (`AWS_PROFILE`,
-`AWS_REGION`, `AWS_ENDPOINT_URL` honored; R2/MinIO work via
-`AWS_ENDPOINT_URL`), GCS via `GOOGLE_APPLICATION_CREDENTIALS`, Azure via
+running the CLI: AWS via the default credential chain (`AWS_PROFILE` honored;
+R2/MinIO work via `AWS_ENDPOINT_URL`, with `AWS_REGION` applied alongside it),
+GCS via `GOOGLE_APPLICATION_CREDENTIALS`, Azure via
 `AZURE_STORAGE_ACCOUNT_NAME` plus `AZURE_STORAGE_ACCOUNT_KEY` or
-`AZURE_STORAGE_SAS_TOKEN`. The CLI generates presigned URLs (24h expiry)
-and hands those to Roboflow; bucket secrets never leave the machine.
+`AZURE_STORAGE_SAS_TOKEN`. For S3/GCS the CLI generates presigned URLs (24h
+expiry); for Azure it appends your SAS token, so those URLs stay valid as long
+as the token does. Either way the URLs are handed to Roboflow and bucket
+secrets never leave the machine.
 
 ## 2. Stage a batch
 
@@ -165,9 +169,11 @@ count plus an `ingest` block with `pending` and `failed` flags. Do not start a
 job while `pending` is true or `failed` is true: the job costs credits and
 would run over incomplete input.
 
-Practical limits: up to 20,000 references per ingest request (auto-chunked),
+Practical limits: up to 20,000 image references per ingest request
+(auto-chunked; video references cap at 5,000 per request and are not chunked),
 ~1,000 videos per batch suggested, image formats jpg/png/webp/bmp/jp2,
-video formats mp4/mov/avi/mkv/flv/wmv/m4v.
+video formats mp4/mov/avi/mkv/flv/wmv/m4v. `batch_processing_staging_batches_list`
+shows every staged batch in the workspace (inputs and job results).
 
 ## 3. Start the job
 
@@ -206,9 +212,12 @@ batch_processing_job_start(
   workers_per_machine=4,            # 1, 2, 4 or 8, optional
   aggregation_format="jsonl",       # or "csv"
   save_image_outputs=True,          # persist crops/visualizations
-  max_video_fps=5,                  # videos only: prediction subsampling
 )
 ```
+
+For videos, set `content_type="videos"` and optionally `max_video_fps=5`
+(prediction subsampling). The tool rejects `max_video_fps` on image jobs and
+`max_image_failure_rate` on video jobs, matching the platform.
 
 Default compute is CPU; use GPU for multiple or large models. Same job_id plus
 an identical definition is idempotent; a divergent one is rejected with a 409.
@@ -231,6 +240,8 @@ MCP equivalents, which return JSON rather than a rendered table:
 - `batch_processing_job_abort(job_id)` / `batch_processing_job_restart(job_id)`
   — stop a run, or retry a failed one (optionally overriding machine type,
   workers, timeout).
+- `batch_processing_jobs_list()` — the workspace's recent jobs, for finding a
+  job id you did not keep.
 
 ## 5. Download results
 
@@ -250,9 +261,11 @@ exported, and `--part-name <part>` to fetch one part of a multipart batch.
 
 The MCP tool `batch_processing_staging_batch_files_list(batch_id="<job-id>-export")`
 lists the same files with signed `downloadURL`s (~24h expiry) so a host with no
-shell can still fetch them. Archives (`.tar` / `.tar.gz`) must be unpacked
-after download, and listings are capped at 10,000 entries per call — past that
-scale use `export-batch`, or import the source data into the workspace with
-datasources (ELT) and work inside Roboflow.
+shell can still fetch them. Export batches are multipart: the tool selects the
+part automatically when there is exactly one, and otherwise asks you to pass
+`part_name` (the parts are in `batch_processing_staging_batch_get`). Archives
+(`.tar` / `.tar.gz`) must be unpacked after download, and listings are capped
+at 10,000 entries per call — past that scale use `export-batch`, or import the
+source data into the workspace with datasources (ELT) and work inside Roboflow.
 
 Do this within 7 days: staged inputs and results expire.

--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -53,6 +53,37 @@ credentials. Everything after staging is server-side via MCP tools:
 The `batch_processing_guide` MCP tool returns this recipe plus an echo of
 the arguments you pass it; it never touches files or the network.
 
+## The master tool: `batch_processing_run`
+
+Prefer `batch_processing_run(batch_id, workflow_id, ...)` to drive the whole
+flow. Each call inspects the current state, advances what it can, waits up
+to `wait_seconds` (bounded) and returns a status:
+
+- `staging_required` — no batch yet; the response contains the exact CLI
+  commands (already wired to a webhook relay via `--notifications-url`) and
+  cloud-credential env-var guidance. Run them, then call again.
+- `ingest_in_progress` — files still registering; call again.
+- `running` — the job was started (with the relay as its notifications URL)
+  or is still working; includes stage progress and relayed events.
+- `completed` — includes the export batch id and the first result files with
+  signed download URLs.
+- `failed` — includes logs and a restart hint.
+
+Pass the returned `job_id` and `relay_id` back on every follow-up call to
+resume; the server holds no state between calls.
+
+## Webhook events
+
+Jobs and ingests can notify a webhook. `batch_processing_run` wires this
+automatically to the MCP server's relay
+(`/webhooks/batch-processing/<relay_id>`); the platform POSTs job
+success/failure (`roboflow-batch-job-notification-v1`) and ingest-status
+events there. Read them with `batch_processing_events_poll(relay_id)`
+between calls, or just re-call `batch_processing_run`. Events are advisory:
+confirm real state with `batch_processing_job_get`. Users with their own
+webhook receiver can instead pass `notifications_url` to
+`batch_processing_job_start` or `--notifications-url` on CLI commands.
+
 ## 1. Install the CLI
 
 ```bash
@@ -61,9 +92,13 @@ pip install inference-cli
 pip install 'inference-cli[cloud-storage]'
 ```
 
-Cloud credentials are picked up from the standard env chains (AWS
-credentials/profile, `GOOGLE_APPLICATION_CREDENTIALS`, or
-`AZURE_STORAGE_ACCOUNT_NAME` + key/SAS).
+Cloud credentials are picked up from the standard env chains on the machine
+running the CLI: AWS via the default credential chain (`AWS_PROFILE`,
+`AWS_REGION`, `AWS_ENDPOINT_URL` honored; R2/MinIO work via
+`AWS_ENDPOINT_URL`), GCS via `GOOGLE_APPLICATION_CREDENTIALS`, Azure via
+`AZURE_STORAGE_ACCOUNT_NAME` plus `AZURE_STORAGE_ACCOUNT_KEY` or
+`AZURE_STORAGE_SAS_TOKEN`. The CLI generates presigned URLs (24h expiry)
+and hands those to Roboflow; bucket secrets never leave the machine.
 
 ## 2. Stage a batch
 

--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roboflow-batch-processing
-description: Use when processing a huge number of images or videos with a Roboflow Workflow WITHOUT importing them into Roboflow — staging local or cloud files with the inference-cli, starting and monitoring batch processing jobs, downloading results, and choosing between batch processing (ETL) and datasource bucket mirroring (ELT).
+description: Use when processing many Asset Library images or external images/videos with a Roboflow Workflow, including selecting Asset Library inputs, staging local or cloud files with the inference-cli, monitoring jobs, downloading results, and choosing between batch processing (ETL) and datasource bucket mirroring (ELT).
 ---
 
 > **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
@@ -8,9 +8,23 @@ description: Use when processing a huge number of images or videos with a Robofl
 # Batch Processing
 
 Run a Roboflow Workflow over a very large set of images or videos on
-Roboflow's autoscaling compute, without importing anything into the
-workspace. Files are staged into temporary Data Staging batches, a job
-processes them, and results are exported back to staging for download.
+Roboflow's autoscaling compute. Existing Asset Library images use the
+platform-owned selection and staging pipeline. External files are staged into
+temporary Data Staging batches, processed, and exported back to staging for
+download without importing them into the workspace.
+
+## Choose the input path first
+
+- **Asset Library images:** call
+  `batch_processing_asset_library_job_create` with a stable idempotency key and
+  exactly one selection: `image_ids`, `query`, or `all_images=true`. The
+  platform performs access checks, selects the files, stages them, verifies
+  Workflow compatibility, bills, and registers the durable job. Poll the
+  returned `taskId` with `batch_processing_asset_library_task_get` until the
+  task is terminal; then monitor its `jobId` with `batch_processing_job_get`.
+- **Local, cloud, or reference-file inputs:** use
+  `batch_processing_guide` and `batch_processing_run` as described below. File
+  staging and result export must run on the machine that can access the files.
 
 ## Batch processing vs datasources (ETL vs ELT)
 
@@ -55,7 +69,8 @@ write the user's disk:
 
 Everything in between needs only an API key, so it works either way: the MCP
 tools (`batch_processing_run`, `_job_start`, `_job_get`, `_jobs_list`,
-`_job_logs`, `_job_abort`, `_job_restart`, `batch_processing_staging_*`) or
+`_job_logs`, `_job_abort`, `_job_restart`,
+`batch_processing_asset_library_*`, `batch_processing_staging_*`) or
 the equivalent CLI commands. Prefer the MCP tools when the host has no shell or the user has
 no local `inference-cli`; prefer the CLI when the user is already in a
 terminal. The full command set for both content types is in sections 1-5.
@@ -73,6 +88,8 @@ returns immediately with a status:
 - `staging_required` — no batch yet; the response contains the CLI commands
   for the whole run plus cloud-credential guidance. Run them, then call again.
 - `ingest_in_progress` — files still registering.
+- `ingest_failed` — ingest failed or returned an unknown shard state; no paid
+  job was started.
 - `running` — the job was started or is still working; includes stage progress.
 - `completed` — includes the export batch id and the first result files with
   signed download URLs.
@@ -90,7 +107,7 @@ genuinely different settings: either re-call with the original settings, or
 pass an explicit `job_id` for a separate run.
 
 For the advanced knobs (`max_runtime_seconds`, `max_parallel_tasks`,
-`max_image_failure_rate`, `image_outputs_to_save`, `part_name`) use
+`max_image_failure_rate`, `image_outputs_to_save`) use
 `batch_processing_job_start` directly.
 
 ## Webhooks
@@ -212,6 +229,7 @@ MCP equivalent:
 
 ```
 batch_processing_job_start(
+  job_id="my-stable-job-id",           # required; reuse for retries
   batch_id="my-batch", workflow_id="my-workflow",
   content_type="images",            # or "videos"
   machine_type="gpu",               # cpu|gpu, optional
@@ -245,7 +263,11 @@ too. `workers_per_machine` (1/2/4/8) then scales throughput on one machine:
 more workers means better utilization but a higher OOM risk.
 
 Same job_id plus an identical definition is idempotent; a divergent one is
-rejected with a 409.
+rejected with a 409. The tool checks that ingest is complete before the paid
+registration call. For a multipart input, pass `part_name`; it is also
+supported by `batch_processing_run`. Both tools default to the current
+`inference-models` backend; use `inference_backend="old-inference"` only for a
+known compatibility requirement.
 
 ## 4. Monitor
 
@@ -265,8 +287,9 @@ MCP equivalents, which return JSON rather than a rendered table:
 - `batch_processing_job_abort(job_id)` / `batch_processing_job_restart(job_id)`
   — stop a run, or retry a failed one (optionally overriding machine type,
   workers, timeout).
-- `batch_processing_jobs_list()` — the workspace's recent jobs, for finding a
-  job id you did not keep.
+- `batch_processing_jobs_list(search=...)` — the workspace's recent Workflow
+  jobs, for finding a job id you did not keep. Internal TensorRT compilation
+  jobs are excluded.
 
 ## 5. Download results
 

--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -225,8 +225,27 @@ For videos, set `content_type="videos"` and optionally `max_video_fps=5`
 (prediction subsampling). The tool rejects `max_video_fps` on image jobs and
 `max_image_failure_rate` on video jobs, matching the platform.
 
-Default compute is CPU; use GPU for multiple or large models. Same job_id plus
-an identical definition is idempotent; a divergent one is rejected with a 409.
+### Choosing cpu vs gpu (`machine_type`)
+
+Default compute is CPU. Decide with two quick checks before starting a paid
+job over the whole batch:
+
+1. **Test-run the Workflow on one representative image** (`workflows_run` MCP
+   tool, or the hosted API) and measure the wall time. Run it twice and time
+   the second call (the first may cold-start). If a single image takes more
+   than about a second of model time, CPU workers will crawl through a large
+   batch: take `gpu`.
+2. **Inspect the Workflow spec** (`workflows_get`): count the model steps and
+   note their sizes. One small fine-tuned detector/classifier: `cpu` is the
+   cheapest and usually enough. Several models chained, or any large
+   foundation model (SAM family, CLIP, OCR, VLM blocks): `gpu`.
+
+Videos multiply per-frame work with `--max-video-fps`, so lean `gpu` there
+too. `workers_per_machine` (1/2/4/8) then scales throughput on one machine:
+more workers means better utilization but a higher OOM risk.
+
+Same job_id plus an identical definition is idempotent; a divergent one is
+rejected with a 409.
 
 ## 4. Monitor
 

--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: roboflow-batch-processing
+description: Use when processing a huge number of images or videos with a Roboflow Workflow WITHOUT importing them into Roboflow — staging local or cloud files with the inference-cli, starting and monitoring batch processing jobs, downloading results, and choosing between batch processing (ETL) and datasource bucket mirroring (ELT).
+---
+
+> **For agents — source-of-truth:** This skill is authored in [`roboflow/computer-vision-skills`](https://github.com/roboflow/computer-vision-skills) and shipped with the Roboflow plugin. If your client has loaded the plugin (you'll see `roboflow:<name>` skills in your available skills list), use those local skills — they're read fresh from disk every session. The same content served as MCP resources at `roboflow://skills/<name>/...` is a fallback for clients without the plugin and may lag this repo. **Don't call `ReadMcpResourceTool` for `roboflow://skills/...` URIs when a local `roboflow:<name>` skill is available.**
+
+# Batch Processing
+
+Run a Roboflow Workflow over a very large set of images or videos on
+Roboflow's autoscaling compute, without importing anything into the
+workspace. Files are staged into temporary Data Staging batches, a job
+processes them, and results are exported back to staging for download.
+
+## Batch processing vs datasources (ETL vs ELT)
+
+Two pipelines exist for "I have a ton of files in a bucket/on disk". Pick by
+what the user wants to end up with:
+
+- **Batch processing (this skill, ETL):** run a model/Workflow over the
+  files and get the results out. Nothing lands in the Roboflow workspace;
+  staged data expires after ~7 days. Best for one-off or recurring bulk
+  inference over local disks or cloud buckets.
+- **Datasources / bucket mirror (ELT, see the `cloud-storage` skill):**
+  import the files INTO the workspace first for labeling, curation, and
+  training, then work on them inside Roboflow.
+
+Rule of thumb: "process and give me the outputs" → batch processing;
+"get these into Roboflow" → datasources (`connect_cloud_storage`).
+
+## Prerequisites
+
+- The workspace needs the batch-processing feature. Gated calls fail with a
+  402 "Batch processing is not enabled for this workspace. Upgrade your plan
+  or contact sales at https://roboflow.com/sales."
+- Jobs consume credits; the workspace must have a positive balance.
+- The Workflow must already exist in the workspace (`workflows_list`,
+  `workflows_create`). Jobs reference it by `workflow_id`; there is no
+  inline-spec option.
+- API key: set `ROBOFLOW_API_KEY` in the environment (mint one with the
+  `api_keys_create` MCP tool). Never have the user paste a private key into
+  chat.
+
+## Where each step runs
+
+Staging uploads run client-side with the inference-cli, on the machine that
+can reach the files (local disk) or with the user's cloud credentials
+(bucket sources). The MCP server cannot read the user's filesystem or cloud
+credentials. Everything after staging is server-side via MCP tools:
+`batch_processing_job_start`, `_job_get`, `_job_logs`, `_job_abort`,
+`_job_restart`, `batch_processing_staging_*`.
+
+The `batch_processing_guide` MCP tool returns this recipe plus an echo of
+the arguments you pass it; it never touches files or the network.
+
+## 1. Install the CLI
+
+```bash
+pip install inference-cli
+# For s3:// gs:// az:// sources:
+pip install 'inference-cli[cloud-storage]'
+```
+
+Cloud credentials are picked up from the standard env chains (AWS
+credentials/profile, `GOOGLE_APPLICATION_CREDENTIALS`, or
+`AZURE_STORAGE_ACCOUNT_NAME` + key/SAS).
+
+## 2. Stage a batch
+
+Batch ids: lowercase letters, digits, `-` or `_`. Staged batches expire
+after ~7 days.
+
+```bash
+# Local images (>32 images are packed into tar shards automatically)
+inference rf-cloud data-staging create-batch-of-images \
+  --batch-id my-batch --images-dir ./images
+
+# Local videos (uploaded one by one via signed URLs)
+inference rf-cloud data-staging create-batch-of-videos \
+  --batch-id my-batch --videos-dir ./videos
+
+# Cloud bucket (S3/GCS/Azure; glob over object paths)
+inference rf-cloud data-staging create-batch-of-images \
+  --batch-id my-batch --data-source cloud-storage \
+  --bucket-path 's3://my-bucket/images/**/*.jpg'
+
+# References file: JSONL lines of {"name": ..., "url": "https://..."}
+inference rf-cloud data-staging create-batch-of-images \
+  --batch-id my-batch --data-source references-file --references refs.jsonl
+```
+
+Sharded, cloud-storage, and references ingests are asynchronous. Wait until
+the batch is fully ingested before starting a job: poll the
+`batch_processing_staging_batch_get` MCP tool (file count plus per-shard
+ingest statuses), or `inference rf-cloud data-staging show-batch-details -b
+my-batch` / `list-ingest-details` from the CLI.
+
+Practical limits: up to 20,000 references per ingest request (auto-chunked),
+~1,000 videos per batch suggested, image formats jpg/png/webp/bmp/jp2,
+video formats mp4/mov/avi/mkv/flv/wmv/m4v.
+
+## 3. Start the job
+
+Prefer the MCP tool:
+
+```
+batch_processing_job_start(
+  batch_id="my-batch", workflow_id="my-workflow",
+  content_type="images",            # or "videos"
+  machine_type="gpu",               # cpu|gpu, optional
+  workers_per_machine=4,            # 1/2/4/8, optional
+  aggregation_format="jsonl",       # or "csv"
+  save_image_outputs=True,          # persist crops/visualizations
+  max_video_fps=5,                  # videos only: prediction subsampling
+)
+```
+
+CLI equivalent: `inference rf-cloud batch-processing
+process-images-with-workflow -b my-batch -w my-workflow -mt gpu` (or
+`process-videos-with-workflow`). Same job_id + identical definition is
+idempotent; a divergent definition is rejected with a 409.
+
+## 4. Monitor
+
+- `batch_processing_job_get(job_id)` — status, current/planned stages,
+  per-stage progress, output batches; `job.isTerminal` + `job.error` are the
+  end states.
+- `batch_processing_job_logs(job_id)` — info/error logs for diagnosis.
+- `batch_processing_job_abort(job_id)` / `batch_processing_job_restart(job_id)`
+  — stop a run, or retry a failed one (optionally overriding machine type,
+  workers, timeout).
+
+## 5. Download results
+
+Results land in Data Staging as platform-generated batches:
+`<job-id>-processing` (raw per-shard outputs) and `<job-id>-export`
+(packaged, downloadable archives).
+
+- List with `batch_processing_staging_batch_files_list(batch_id="<job-id>-export")`;
+  entries carry signed `downloadURL`s (~24h expiry). Archives (`.tar` /
+  `.tar.gz`) must be unpacked after download.
+- Listings are capped at 10,000 entries per call. Past that scale, download
+  with the CLI instead (`inference rf-cloud data-staging export-batch -b
+  <job-id>-export -t ./results`, resumable), or import the source data into
+  the workspace with datasources (ELT) and work inside Roboflow.
+- Do this within 7 days: staged inputs and results expire.

--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -97,14 +97,17 @@ returns immediately with a status:
 
 **The server never waits on your behalf.** Non-terminal responses carry
 `retryAfterSeconds`; sleep that long on your side, then call again with the
-returned `job_id` to resume. The server holds no state between calls.
+returned `job_id` and the same `batch_id` to resume. Omit optional creation
+settings on a read-only resume: the paid job's stored definition is
+authoritative. The server holds no state between calls.
 
 The job is started under an id derived from (workspace, batch, workflow), so
 retrying after a lost response re-registers the same job instead of paying for
 a second run. (The platform checks credits before that idempotency comparison,
 so a retry can still see a 429 first.) A 409 means that id already exists with
-genuinely different settings: either re-call with the original settings, or
-pass an explicit `job_id` for a separate run.
+different batch/Workflow identity or conflicts with an optional setting you
+explicitly supplied. Inspect the job, omit optional settings to monitor it as
+stored, or pass a new explicit `job_id` for a separate run.
 
 For the advanced knobs (`max_runtime_seconds`, `max_parallel_tasks`,
 `max_image_failure_rate`, `image_outputs_to_save`) use

--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -41,48 +41,67 @@ Rule of thumb: "process and give me the outputs" → batch processing;
   `api_keys_create` MCP tool). Never have the user paste a private key into
   chat.
 
-## Where each step runs
+## Where each step runs, and why
 
-Staging uploads run client-side with the inference-cli, on the machine that
-can reach the files (local disk) or with the user's cloud credentials
-(bucket sources). The MCP server cannot read the user's filesystem or cloud
-credentials. Everything after staging is server-side via MCP tools:
-`batch_processing_job_start`, `_job_get`, `_job_logs`, `_job_abort`,
-`_job_restart`, `batch_processing_staging_*`.
+Two steps are inference-cli only, because the MCP server can neither read nor
+write the user's disk:
 
-The `batch_processing_guide` MCP tool returns this recipe plus an echo of
-the arguments you pass it; it never touches files or the network.
+- **Staging** runs on the machine that can reach the files (local disk) or
+  with the user's cloud credentials (bucket sources).
+- **Exporting results** (`export-batch`) downloads into a local directory.
+
+Everything in between needs only an API key, so it works either way: the MCP
+tools (`batch_processing_run`, `_job_start`, `_job_get`, `_job_logs`,
+`_job_abort`, `_job_restart`, `batch_processing_staging_*`) or the equivalent
+CLI commands. Prefer the MCP tools when the host has no shell or the user has
+no local `inference-cli`; prefer the CLI when the user is already in a
+terminal. The full command set for both content types is in sections 1-5.
+
+The `batch_processing_guide` MCP tool routes a request: it settles the batch
+id, picks the staging source, and returns the exact ordered commands. It
+never touches files or the network, and it does not repeat this document.
 
 ## The master tool: `batch_processing_run`
 
-Prefer `batch_processing_run(batch_id, workflow_id, ...)` to drive the whole
-flow. Each call inspects the current state, advances what it can, waits up
-to `wait_seconds` (bounded) and returns a status:
+Prefer `batch_processing_run(batch_id, workflow_id, content_type, ...)` to
+drive the flow. Each call reads current state, advances what it can, and
+returns immediately with a status:
 
-- `staging_required` — no batch yet; the response contains the exact CLI
-  commands (already wired to a webhook relay via `--notifications-url`) and
-  cloud-credential env-var guidance. Run them, then call again.
-- `ingest_in_progress` — files still registering; call again.
-- `running` — the job was started (with the relay as its notifications URL)
-  or is still working; includes stage progress and relayed events.
+- `staging_required` — no batch yet; the response contains the CLI commands
+  for the whole run plus cloud-credential guidance. Run them, then call again.
+- `ingest_in_progress` — files still registering.
+- `running` — the job was started or is still working; includes stage progress.
 - `completed` — includes the export batch id and the first result files with
   signed download URLs.
 - `failed` — includes logs and a restart hint.
 
-Pass the returned `job_id` and `relay_id` back on every follow-up call to
-resume; the server holds no state between calls.
+**The server never waits on your behalf.** Non-terminal responses carry
+`retryAfterSeconds`; sleep that long on your side, then call again with the
+returned `job_id` to resume. The server holds no state between calls.
 
-## Webhook events
+The job is started under an id derived from (workspace, batch, workflow), so
+retrying after a lost response re-registers the same job instead of paying for
+a second run. A 409 means that id already exists with genuinely different
+settings: either re-call with the original settings, or pass an explicit
+`job_id` for a separate run.
 
-Jobs and ingests can notify a webhook. `batch_processing_run` wires this
-automatically to the MCP server's relay
-(`/webhooks/batch-processing/<relay_id>`); the platform POSTs job
-success/failure (`roboflow-batch-job-notification-v1`) and ingest-status
-events there. Read them with `batch_processing_events_poll(relay_id)`
-between calls, or just re-call `batch_processing_run`. Events are advisory:
-confirm real state with `batch_processing_job_get`. Users with their own
-webhook receiver can instead pass `notifications_url` to
-`batch_processing_job_start` or `--notifications-url` on CLI commands.
+For the advanced knobs (`max_runtime_seconds`, `max_parallel_tasks`,
+`max_image_failure_rate`, `image_outputs_to_save`, `part_name`) use
+`batch_processing_job_start` directly.
+
+## Webhooks
+
+Roboflow will POST job and ingest notifications to a URL you control. There is
+no MCP-side relay: pass `notifications_url` to `batch_processing_job_start`, or
+`--notifications-url` on the CLI commands, pointing at your own receiver. The
+POST carries an `Authorization` header with your publishable key.
+
+Caveat: local **video** staging does not support `--notifications-url` (the CLI
+prints a warning and drops it). Local image, cloud-storage and references-file
+ingests all support it.
+
+If you have no receiver, just poll `batch_processing_job_get` (or
+`batch_processing_run`, which reports progress on each call).
 
 ## 1. Install the CLI
 
@@ -114,21 +133,37 @@ inference rf-cloud data-staging create-batch-of-images \
 inference rf-cloud data-staging create-batch-of-videos \
   --batch-id my-batch --videos-dir ./videos
 
-# Cloud bucket (S3/GCS/Azure; glob over object paths)
+# Cloud bucket (S3/GCS/Azure; glob over object paths).
+# Videos work exactly the same way: create-batch-of-videos.
 inference rf-cloud data-staging create-batch-of-images \
   --batch-id my-batch --data-source cloud-storage \
   --bucket-path 's3://my-bucket/images/**/*.jpg'
+
+inference rf-cloud data-staging create-batch-of-videos \
+  --batch-id my-batch --data-source cloud-storage \
+  --bucket-path 's3://my-bucket/videos/**/*.mp4'
 
 # References file: JSONL lines of {"name": ..., "url": "https://..."}
 inference rf-cloud data-staging create-batch-of-images \
   --batch-id my-batch --data-source references-file --references refs.jsonl
 ```
 
+Images vs videos is a choice you make, not something inferred from the path:
+`create-batch-of-images` and `create-batch-of-videos` both accept every data
+source. Pick the one matching the content.
+
 Sharded, cloud-storage, and references ingests are asynchronous. Wait until
-the batch is fully ingested before starting a job: poll the
-`batch_processing_staging_batch_get` MCP tool (file count plus per-shard
-ingest statuses), or `inference rf-cloud data-staging show-batch-details -b
-my-batch` / `list-ingest-details` from the CLI.
+the batch is fully ingested before starting a job:
+
+```bash
+inference rf-cloud data-staging show-batch-details --batch-id my-batch
+inference rf-cloud data-staging list-ingest-details --batch-id my-batch
+```
+
+or the `batch_processing_staging_batch_get` MCP tool, which returns the file
+count plus an `ingest` block with `pending` and `failed` flags. Do not start a
+job while `pending` is true or `failed` is true: the job costs credits and
+would run over incomplete input.
 
 Practical limits: up to 20,000 references per ingest request (auto-chunked),
 ~1,000 videos per batch suggested, image formats jpg/png/webp/bmp/jp2,
@@ -136,26 +171,58 @@ video formats mp4/mov/avi/mkv/flv/wmv/m4v.
 
 ## 3. Start the job
 
-Prefer the MCP tool:
+CLI, images:
+
+```bash
+inference rf-cloud batch-processing process-images-with-workflow \
+  --batch-id my-batch --workflow-id my-workflow --machine-type gpu
+```
+
+CLI, videos:
+
+```bash
+inference rf-cloud batch-processing process-videos-with-workflow \
+  --batch-id my-batch --workflow-id my-workflow --machine-type gpu \
+  --max-video-fps 5
+```
+
+Shared optional flags: `--workers-per-machine 1|2|4|8`,
+`--aggregation-format jsonl|csv`, `--save-image-outputs`,
+`--image-outputs-to-save <name>`, `--image-input-name <name>`,
+`--workflow-params params.json`, `--max-runtime-seconds <n>`,
+`--max-parallel-tasks <n>`, `--job-id <id>`, `--job-name <name>`,
+`--notifications-url <url>`, `--part-name <part>`.
+
+Images only: `--max-image-failure-rate 0.0-1.0` (the server rejects it on
+video jobs). Videos only: `--max-video-fps <n>`.
+
+MCP equivalent:
 
 ```
 batch_processing_job_start(
   batch_id="my-batch", workflow_id="my-workflow",
   content_type="images",            # or "videos"
   machine_type="gpu",               # cpu|gpu, optional
-  workers_per_machine=4,            # 1/2/4/8, optional
+  workers_per_machine=4,            # 1, 2, 4 or 8, optional
   aggregation_format="jsonl",       # or "csv"
   save_image_outputs=True,          # persist crops/visualizations
   max_video_fps=5,                  # videos only: prediction subsampling
 )
 ```
 
-CLI equivalent: `inference rf-cloud batch-processing
-process-images-with-workflow -b my-batch -w my-workflow -mt gpu` (or
-`process-videos-with-workflow`). Same job_id + identical definition is
-idempotent; a divergent definition is rejected with a 409.
+Default compute is CPU; use GPU for multiple or large models. Same job_id plus
+an identical definition is idempotent; a divergent one is rejected with a 409.
 
 ## 4. Monitor
+
+```bash
+inference rf-cloud batch-processing show-job-details --job-id my-job
+inference rf-cloud batch-processing fetch-logs --job-id my-job
+inference rf-cloud batch-processing abort-job --job-id my-job
+inference rf-cloud batch-processing restart-job --job-id my-job
+```
+
+MCP equivalents, which return JSON rather than a rendered table:
 
 - `batch_processing_job_get(job_id)` — status, current/planned stages,
   per-stage progress, output batches; `job.isTerminal` + `job.error` are the
@@ -171,11 +238,21 @@ Results land in Data Staging as platform-generated batches:
 `<job-id>-processing` (raw per-shard outputs) and `<job-id>-export`
 (packaged, downloadable archives).
 
-- List with `batch_processing_staging_batch_files_list(batch_id="<job-id>-export")`;
-  entries carry signed `downloadURL`s (~24h expiry). Archives (`.tar` /
-  `.tar.gz`) must be unpacked after download.
-- Listings are capped at 10,000 entries per call. Past that scale, download
-  with the CLI instead (`inference rf-cloud data-staging export-batch -b
-  <job-id>-export -t ./results`, resumable), or import the source data into
-  the workspace with datasources (ELT) and work inside Roboflow.
-- Do this within 7 days: staged inputs and results expire.
+Downloading writes to disk, so this step is CLI only:
+
+```bash
+inference rf-cloud data-staging export-batch \
+  --batch-id my-job-export --target-dir ./results
+```
+
+It is resumable; add `--override-existing` to re-pull content already
+exported, and `--part-name <part>` to fetch one part of a multipart batch.
+
+The MCP tool `batch_processing_staging_batch_files_list(batch_id="<job-id>-export")`
+lists the same files with signed `downloadURL`s (~24h expiry) so a host with no
+shell can still fetch them. Archives (`.tar` / `.tar.gz`) must be unpacked
+after download, and listings are capped at 10,000 entries per call — past that
+scale use `export-batch`, or import the source data into the workspace with
+datasources (ELT) and work inside Roboflow.
+
+Do this within 7 days: staged inputs and results expire.

--- a/skills/cloud-storage/SKILL.md
+++ b/skills/cloud-storage/SKILL.md
@@ -20,8 +20,10 @@ in automatically. Two pieces work together:
 > specific project/dataset today.
 
 > Only want to run a model/Workflow over the files and collect the outputs,
-> without importing anything into Roboflow? That is batch processing (ETL) —
-> see the `roboflow-batch-processing` skill instead.
+> without importing anything into Roboflow? That is batch processing — see the
+> `roboflow-batch-processing` skill. Mirroring composes with it too: imported
+> files become Asset Library images, and bulk predictions over them run as
+> Asset Library batch processing jobs (same skill).
 
 ## Fast path — one call
 

--- a/skills/cloud-storage/SKILL.md
+++ b/skills/cloud-storage/SKILL.md
@@ -19,6 +19,10 @@ in automatically. Two pieces work together:
 > Imports land at the **workspace** level. The datasource API cannot target a
 > specific project/dataset today.
 
+> Only want to run a model/Workflow over the files and collect the outputs,
+> without importing anything into Roboflow? That is batch processing (ETL) —
+> see the `roboflow-batch-processing` skill instead.
+
 ## Fast path — one call
 
 `connect_cloud_storage` does the whole flow in one shot: (optionally) create a

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -95,7 +95,7 @@ Surfaces: Roboflow web UI, `inference rf-cloud` CLI, and REST API.
 ### Flow
 
 1. Have a saved Workflow in your workspace.
-2. Stage inputs as a Data Staging batch (local directory, JSONL of signed URLs, or cloud-storage path on S3 / GCS / Azure).
+2. Provide inputs: an Asset Library selection (the platform stages it for you), or stage external files yourself as a Data Staging batch (local directory, JSONL of signed URLs, or cloud-storage path on S3 / GCS / Azure).
 3. Submit a job referencing the Workflow + input batch; choose CPU or GPU.
 4. Monitor — poll job status or register a webhook.
 5. Export the output batch as JSON.

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -82,6 +82,8 @@ Mitigation strategies:
 
 ## Batch Processing
 
+> For the full recipe (staging, jobs, monitoring, results, MCP tools), see the `roboflow-batch-processing` skill; this section is only the deployment comparison.
+
 **What it is.** A Roboflow-managed cloud service that runs a Workflow over a batch of images or videos asynchronously, provisioning the infrastructure for you. *"Ideal for asynchronously processing large amounts of data."* — [Roboflow docs](https://docs.roboflow.com/deploy/batch-processing).
 
 **Problem it solves.** Bulk inference over thousands to millions of files without standing up your own GPUs, queues, or autoscaler. You hand Roboflow a Workflow plus a batch of inputs, pay per job, and get JSON results back when the job finishes.


### PR DESCRIPTION
Adds the `batch-processing` skill, served by the MCP server at `roboflow://skills/batch-processing/SKILL` and shipped with the Roboflow plugin, and adds routing pointers to the `cloud-storage` and `inference` skills.

## What it covers

- The teaching model: every batch processing job runs over a Data Staging batch; the two input paths differ only in who fills it. The platform stages Asset Library selections for you; you stage external files yourself with the inference-cli. A three-question decision tree routes between Asset Library jobs, staged jobs, and datasource (bucket mirror) imports, with ETL/ELT demoted to parentheticals. `cloud-storage` points back here and notes the composition: mirrored images become Asset Library images and can be batch-processed as Asset Library jobs.
- Prerequisites: the batch-processing feature gate (402 with an upgrade/contact-sales message), credits, an existing Workflow, and safe API key handling.
- Which steps run where, and why: staging and result export can only happen in the inference-cli, because the MCP server can neither read nor write the user's disk. Everything between needs only an API key, so the skill gives the CLI commands and the MCP equivalents side by side and says when to reach for which.
- The full CLI lifecycle for images **and** videos: install (including the `cloud-storage` extra), staging from local disk, cloud buckets (S3/GCS/Azure with the credential env vars per provider; S3/GCS get 24h presigned URLs while Azure rides the SAS token) or references files, ingest inspection, `process-images-with-workflow` / `process-videos-with-workflow` with their flags, `show-job-details` / `fetch-logs` / `abort-job` / `restart-job`, and `export-batch`.
- Practical limits verified against the CLI and platform source: image references chunk at 20,000 per ingest request, video references cap at 5,000 and are not chunked, ~1,000 videos per batch suggested.
- The MCP tool surface: the `batch_processing_run` master tool, which is single-shot and returns `retryAfterSeconds` for the host to poll on rather than waiting server-side, plus the staging reads, `jobs_list` (entries labeled with `inputSource`: `asset-library` or `staged-batch`), and the job lifecycle tools. The `staged_job_start` example is valid as written (video-only knobs are called out separately, since the tool rejects `max_video_fps` on image jobs).
- Webhooks: bring-your-own via `notifications_url` / `--notifications-url`, including the two ingests that drop the flag (local video staging, and simple local image batches of 32 files or fewer). The POST carries an Authorization header with the publishable key.
- Results: the `<job-id>-export` staging batch is multipart; the files-list tool auto-selects the part when there is exactly one and otherwise takes `part_name` (parts come from `batch_processing_staging_batch_get`). Also covers the resumable `export-batch` download, signed download URLs for shell-less hosts, the 10k files-list cap, and the 7-day staging TTL.

Images vs videos is presented as an authoring choice rather than something inferred from a path, since `create-batch-of-images` and `create-batch-of-videos` both accept every data source.

## Companion change

The MCP server side (tools, instructions line for this skill) lands in roboflow/roboflow-mcp#129 for INC-318. That PR bumps its submodule pointer at this branch so the skill resource resolves during review; it should be re-pointed at the merged commit once this PR lands. Merge this PR first.

