### PR TITLE
docs: scope the batch_processing_run section to staged batches

### DIFF
--- a/skills/batch-processing/SKILL.md
+++ b/skills/batch-processing/SKILL.md
@@ -86,11 +86,12 @@ The `batch_processing_guide` MCP tool routes a request: it settles the batch
 id, picks the staging source, and returns the exact ordered commands. It
 never touches files or the network, and it does not repeat this document.
 
-## The master tool: `batch_processing_run`
+## The master tool for staged batches: `batch_processing_run`
 
 Prefer `batch_processing_run(batch_id, workflow_id, content_type, ...)` to
-drive the flow. Each call reads current state, advances what it can, and
-returns immediately with a status:
+drive the flow over a staging batch you name (for Asset Library selections,
+use `batch_processing_asset_library_job_create` instead). Each call reads
+current state, advances what it can, and returns immediately with a status:
 
 - `staging_required` — no batch yet; the response contains the CLI commands
   for the whole run plus cloud-credential guidance. Run them, then call again.


### PR DESCRIPTION
Tiny follow-up to #36: the master-tool section header and lead now say batch_processing_run drives a run over a staging batch you name, and route Asset Library selections to batch_processing_asset_library_job_create. Matches the tool description update in roboflow/roboflow-mcp#129 (3c94a82), so a header-skimming agent cannot mistake the master tool for the selection path.